### PR TITLE
Remove Rx interfaces from non RX APIs

### DIFF
--- a/catowser/BrowserNetworking/TransportAdapters/AlamofireHTTPRxVoidAdaptee.swift
+++ b/catowser/BrowserNetworking/TransportAdapters/AlamofireHTTPRxVoidAdaptee.swift
@@ -1,5 +1,5 @@
 //
-//  AlamofireHTTPVoidAdaptee.swift
+//  AlamofireHTTPRxVoidAdaptee.swift
 //  BrowserNetworking
 //
 //  Created by Andrei Ermoshin on 2/10/22.
@@ -13,7 +13,7 @@ import ReactiveSwift
 import Combine
 #endif
 
-final class AlamofireHTTPVoidAdaptee<S, RX: RxVoidInterface>: HTTPRxVoidAdapter where RX.Server == S {
+final class AlamofireHTTPRxVoidAdaptee<S, RX: RxVoidInterface>: HTTPRxVoidAdapter where RX.Server == S {
     typealias Server = S
     typealias ObserverWrapper = RX
 

--- a/catowser/HttpKit/ClientSubscriber.swift
+++ b/catowser/HttpKit/ClientSubscriber.swift
@@ -8,15 +8,15 @@
 
 import Foundation
 
-/// Should be used for async interfaces which use RX library
-public typealias RxSubscriber<R, S, RX: RxInterface> = HttpKit.ClientRxSubscriber<R, S, RX>
-    where RX.Server == S, RX.Observer.Response == R
-public typealias RxVoidSubscriber<S, RX: RxVoidInterface> = HttpKit.ClientRxVoidSubscriber<S, RX>
-    where RX.Server == S
-/// Can be used for async interfaces which do not need RX stuff, like Combine or simple Closures
-public typealias Subscriber<R: ResponseType, S: ServerDescription> = HttpKit.ClientSubscriber<R, S>
-
 extension HttpKit {
+    /// Should be used for async interfaces which use RX library
+    public typealias RxSubscriber<R, S, RX: RxInterface> = ClientRxSubscriber<R, S, RX>
+        where RX.Server == S, RX.Observer.Response == R
+    public typealias RxVoidSubscriber<S, RX: RxVoidInterface> = ClientRxVoidSubscriber<S, RX>
+        where RX.Server == S
+    /// Can be used for async interfaces which do not need RX stuff, like Combine or simple Closures
+    public typealias Subscriber<R: ResponseType, S: ServerDescription> = ClientSubscriber<R, S>
+    
     /// I already don't like this idea and this class, it will be for every endpoint
     /// This is only because I want to support generics for endpoints
     /// The main issue which needs to be solved by this class is to not add ResponseType
@@ -59,8 +59,6 @@ extension HttpKit {
 
 extension HttpKit {
     public typealias RxFreeInterface<R: ResponseType, S: ServerDescription> = DummyRxType<R, S, DummyRxObserver<R>>
-    public class ClientSubscriber<R: ResponseType,
-                                  S: ServerDescription>: ClientRxSubscriber<R, S, RxFreeInterface<R, S>> {
-        
-    }
+    public typealias ClientSubscriber<R: ResponseType,
+                                      S: ServerDescription> = ClientRxSubscriber<R, S, RxFreeInterface<R, S>>
 }

--- a/catowser/HttpKit/DummyRxInterface.swift
+++ b/catowser/HttpKit/DummyRxInterface.swift
@@ -42,9 +42,12 @@ extension HttpKit {
         }
         
         public static func == (lhs: HttpKit.DummyRxType<R, SS, RX>, rhs: HttpKit.DummyRxType<R, SS, RX>) -> Bool {
-            return false
+            return lhs.endpoint == rhs.endpoint
         }
         
-        public func hash(into hasher: inout Hasher) {}
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine("DummyRxType")
+            hasher.combine(endpoint)
+        }
     }
 }

--- a/catowser/HttpKit/HTTPAdapter.swift
+++ b/catowser/HttpKit/HTTPAdapter.swift
@@ -42,7 +42,9 @@ public protocol HTTPAdapter: AnyObject {
     associatedtype Response: ResponseType
     associatedtype Server: ServerDescription
     
-    init(_ handlerType: HttpKit.ResponseHandlingApi<Response, Server, HttpKit.RxFreeInterface<Response, Server>>)
+    typealias RxFreeDummy<R: ResponseType, S: ServerDescription> = HttpKit.RxFreeInterface<R, S>
+    
+    init(_ handlerType: HttpKit.ResponseHandlingApi<Response, Server, RxFreeDummy<Response, Server>>)
     
     func performRequest(_ request: URLRequest,
                         sucessCodes: [Int])
@@ -52,8 +54,8 @@ public protocol HTTPAdapter: AnyObject {
     func wrapperHandler() -> (Result<Response, HttpKit.HttpError>) -> Void
     /// Should refer to simple closure api
     var handlerType: HttpKit.ResponseHandlingApi<Response,
-                                                    Server,
-                                                    HttpKit.RxFreeInterface<Response, Server>> { get set }
+                                                Server,
+                                                RxFreeDummy<Response, Server>> { get set }
     
     /* mutating */ func transferToCombineState(_ promise: @escaping Future<Response, HttpKit.HttpError>.Promise,
                                                _ endpoint: HttpKit.Endpoint<Response, Server>)

--- a/catowser/HttpKit/HttpClient+Combine.swift
+++ b/catowser/HttpKit/HttpClient+Combine.swift
@@ -14,11 +14,11 @@ import Combine
 extension HttpKit.Client {
     public typealias ResponseFuture<T> = Deferred<Publishers.HandleEvents<Future<T, HttpKit.HttpError>>>
     
-    public func cMakeRequest<T, B: HTTPRxAdapter, RX>(for endpoint: HttpKit.Endpoint<T, Server>,
-                                                      withAccessToken accessToken: String?,
-                                                      transport adapter: B,
-                                                      _ subscriber: RxSubscriber<T, Server, RX>) -> ResponseFuture<T>
-    where B.Response == T, B.Server == Server, B.ObserverWrapper == RX {
+    public func cMakeRequest<T, B: HTTPAdapter>(for endpoint: HttpKit.Endpoint<T, Server>,
+                                                withAccessToken accessToken: String?,
+                                                transport adapter: B,
+                                                subscriber: HttpKit.Subscriber<T, Server>) -> ResponseFuture<T>
+    where B.Response == T, B.Server == Server {
         // Can't use Future without Deferred because
         // a Future will begin executing immediately when you create it.
         return Combine.Deferred {
@@ -30,8 +30,7 @@ extension HttpKit.Client {
                 
                 adapter.transferToCombineState(promise, endpoint)
                 subscriber.insert(adapter.handlerType)
-                // TODO: use makeRequest instead
-                self.makeRxRequest(for: endpoint, withAccessToken: accessToken, transport: adapter)
+                self.makeRequest(for: endpoint, withAccessToken: accessToken, transport: adapter)
             }
             return subject.handleEvents(receiveCompletion: { [weak subscriber] _ in
                 // Must capture `adapter` by strong reference comparing to

--- a/catowser/ReactiveHttpKit/HttpClient+RxSwift.swift
+++ b/catowser/ReactiveHttpKit/HttpClient+RxSwift.swift
@@ -17,7 +17,7 @@ extension HttpKit.Client {
     public func rxMakeRequest<T, B: HTTPRxAdapter, RX>(for endpoint: HttpKit.Endpoint<T, Server>,
                                                        withAccessToken accessToken: String?,
                                                        transport adapter: B,
-                                                       _ subscriber: RxSubscriber<T, Server, RX>) -> RxProducer<T>
+                                                       subscriber: HttpKit.RxSubscriber<T, Server, RX>) -> RxProducer<T>
     where B.Response == T, B.Server == Server, B.ObserverWrapper == RX {
         let producer: SignalProducer<T, HttpKit.HttpError> = .init { [weak self] (observer, lifetime) in
             guard let self = self else {
@@ -43,7 +43,7 @@ extension HttpKit.Client {
     public func rxMakeVoidRequest<B: HTTPRxVoidAdapter, RX>(for endpoint: HttpKit.VoidEndpoint<Server>,
                                                             withAccessToken accessToken: String?,
                                                             transport adapter: B,
-                                                            subscriber: RxVoidSubscriber<Server, RX>) -> RxVoidProducer
+                                                            subscriber: HttpKit.RxVoidSubscriber<Server, RX>) -> RxVoidProducer
     where B.Server == Server, B.Observer == RX {
         let producer: SignalProducer<Void, HttpKit.HttpError> = .init { [weak self] (observer, lifetime) in
             guard let self = self else {

--- a/catowser/catowser.xcodeproj/project.pbxproj
+++ b/catowser/catowser.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		755E107227BC3DC500D90AD0 /* AppAsyncApiTypeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755E107027BC3DC500D90AD0 /* AppAsyncApiTypeView.swift */; };
 		755E107427BC3E0800D90AD0 /* AppAsyncApiTypeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755E107327BC3E0800D90AD0 /* AppAsyncApiTypeModel.swift */; };
 		755E107527BC3E0800D90AD0 /* AppAsyncApiTypeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755E107327BC3E0800D90AD0 /* AppAsyncApiTypeModel.swift */; };
+		755E107727BFF85900D90AD0 /* AlamofireHTTPAdaptee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755E107627BFF85900D90AD0 /* AlamofireHTTPAdaptee.swift */; };
 		841022B9224781A20021516F /* LinkTagsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 841022B8224781A20021516F /* LinkTagsViewController.swift */; };
 		841022BD224785340021516F /* LinksBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 841022BC224785340021516F /* LinksBadgeView.swift */; };
 		841022C1224788F80021516F /* LinkTagsViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 841022C0224788F80021516F /* LinkTagsViewController.storyboard */; };
@@ -98,7 +99,7 @@
 		8A0E0EAB224A94E600D86CD7 /* InstagramVideoNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0E0EAA224A94E600D86CD7 /* InstagramVideoNode.swift */; };
 		8A1115EB24837DA400E63114 /* TabAddPositionsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1115EA24837DA400E63114 /* TabAddPositionsModel.swift */; };
 		8A1115EC24837DA400E63114 /* TabAddPositionsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1115EA24837DA400E63114 /* TabAddPositionsModel.swift */; };
-		8A1A1CE727B1966E0052A2A3 /* AlamofireHTTPAdaptee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB0D4102755075700493EC3 /* AlamofireHTTPAdaptee.swift */; };
+		8A1A1CE727B1966E0052A2A3 /* AlamofireHTTPRxAdaptee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB0D4102755075700493EC3 /* AlamofireHTTPRxAdaptee.swift */; };
 		8A1A1CE827B196B80052A2A3 /* AuthChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A978D4823F34909007ECB0C /* AuthChallenge.swift */; };
 		8A1C1C172484E5900098F2F1 /* TabDefaultContentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1C1C162484E5900098F2F1 /* TabDefaultContentModel.swift */; };
 		8A1C1C182484E5900098F2F1 /* TabDefaultContentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1C1C162484E5900098F2F1 /* TabDefaultContentModel.swift */; };
@@ -262,7 +263,7 @@
 		8AB4A1AD27B5335C008030FB /* ClientSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB4A1AB27B53043008030FB /* ClientSubscriber.swift */; };
 		8AB4A1AF27B5522B008030FB /* ClosureWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB4A1AE27B5522B008030FB /* ClosureWrappers.swift */; };
 		8AB4A1B127B55268008030FB /* ResponseHandlingApiType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB4A1B027B55268008030FB /* ResponseHandlingApiType.swift */; };
-		8AB4A1B327B55484008030FB /* AlamofireHTTPVoidAdaptee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB4A1B227B55484008030FB /* AlamofireHTTPVoidAdaptee.swift */; };
+		8AB4A1B327B55484008030FB /* AlamofireHTTPRxVoidAdaptee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB4A1B227B55484008030FB /* AlamofireHTTPRxVoidAdaptee.swift */; };
 		8AB4A1B527B55684008030FB /* HTTPVoidAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB4A1B427B55684008030FB /* HTTPVoidAdapter.swift */; };
 		8AB4A1B727B56CC3008030FB /* ResponseVoidHandlingApiType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB4A1B627B56CC3008030FB /* ResponseVoidHandlingApiType.swift */; };
 		8AB4A1B927B583AB008030FB /* ClosureVoidWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB4A1B827B583AB008030FB /* ClosureVoidWrappers.swift */; };
@@ -652,6 +653,7 @@
 		7509BF9122AF832200F4D701 /* Site+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Site+Extension.swift"; sourceTree = "<group>"; };
 		755E107027BC3DC500D90AD0 /* AppAsyncApiTypeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAsyncApiTypeView.swift; sourceTree = "<group>"; };
 		755E107327BC3E0800D90AD0 /* AppAsyncApiTypeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAsyncApiTypeModel.swift; sourceTree = "<group>"; };
+		755E107627BFF85900D90AD0 /* AlamofireHTTPAdaptee.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlamofireHTTPAdaptee.swift; sourceTree = "<group>"; };
 		767DCB6FAC0282E44CD4A2D7 /* Pods-HttpKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HttpKitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-HttpKitTests/Pods-HttpKitTests.release.xcconfig"; sourceTree = "<group>"; };
 		81B2D2928390EC8BF7C0C9A8 /* Pods-BrowserNetworking.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BrowserNetworking.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BrowserNetworking/Pods-BrowserNetworking.debug.xcconfig"; sourceTree = "<group>"; };
 		841022B8224781A20021516F /* LinkTagsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkTagsViewController.swift; sourceTree = "<group>"; };
@@ -759,11 +761,11 @@
 		8AB022F026258B110053AFF0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8AB0D40A2754AEB500493EC3 /* HttpClient+RxSwift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HttpClient+RxSwift.swift"; sourceTree = "<group>"; };
 		8AB0D40E2754FC9B00493EC3 /* HttpClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpClientTests.swift; sourceTree = "<group>"; };
-		8AB0D4102755075700493EC3 /* AlamofireHTTPAdaptee.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlamofireHTTPAdaptee.swift; sourceTree = "<group>"; };
+		8AB0D4102755075700493EC3 /* AlamofireHTTPRxAdaptee.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlamofireHTTPRxAdaptee.swift; sourceTree = "<group>"; };
 		8AB4A1AB27B53043008030FB /* ClientSubscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientSubscriber.swift; sourceTree = "<group>"; };
 		8AB4A1AE27B5522B008030FB /* ClosureWrappers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosureWrappers.swift; sourceTree = "<group>"; };
 		8AB4A1B027B55268008030FB /* ResponseHandlingApiType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseHandlingApiType.swift; sourceTree = "<group>"; };
-		8AB4A1B227B55484008030FB /* AlamofireHTTPVoidAdaptee.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlamofireHTTPVoidAdaptee.swift; sourceTree = "<group>"; };
+		8AB4A1B227B55484008030FB /* AlamofireHTTPRxVoidAdaptee.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlamofireHTTPRxVoidAdaptee.swift; sourceTree = "<group>"; };
 		8AB4A1B427B55684008030FB /* HTTPVoidAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPVoidAdapter.swift; sourceTree = "<group>"; };
 		8AB4A1B627B56CC3008030FB /* ResponseVoidHandlingApiType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseVoidHandlingApiType.swift; sourceTree = "<group>"; };
 		8AB4A1B827B583AB008030FB /* ClosureVoidWrappers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosureVoidWrappers.swift; sourceTree = "<group>"; };
@@ -1327,8 +1329,9 @@
 		8A1A1CE627B1963F0052A2A3 /* TransportAdapters */ = {
 			isa = PBXGroup;
 			children = (
-				8AB0D4102755075700493EC3 /* AlamofireHTTPAdaptee.swift */,
-				8AB4A1B227B55484008030FB /* AlamofireHTTPVoidAdaptee.swift */,
+				8AB0D4102755075700493EC3 /* AlamofireHTTPRxAdaptee.swift */,
+				8AB4A1B227B55484008030FB /* AlamofireHTTPRxVoidAdaptee.swift */,
+				755E107627BFF85900D90AD0 /* AlamofireHTTPAdaptee.swift */,
 			);
 			path = TransportAdapters;
 			sourceTree = "<group>";
@@ -2741,16 +2744,17 @@
 				8A277192268E4AA400D8878C /* GoogleJSONDNSoHTTPsEndpoint.swift in Sources */,
 				8A27722E268E4AD400D8878C /* SearchEngine+OpenSearchParser.swift in Sources */,
 				8A2771FB268E4AC900D8878C /* SearchEngine.swift in Sources */,
-				8AB4A1B327B55484008030FB /* AlamofireHTTPVoidAdaptee.swift in Sources */,
+				8AB4A1B327B55484008030FB /* AlamofireHTTPRxVoidAdaptee.swift in Sources */,
 				8A2771A3268E4AA800D8878C /* GoogleJSONDNSoHTTPsEndpoint+AsyncAwait.swift in Sources */,
 				8A1A1CE827B196B80052A2A3 /* AuthChallenge.swift in Sources */,
 				8ABDB0B127B24E3900D6EDE7 /* Downloadable.swift in Sources */,
+				755E107727BFF85900D90AD0 /* AlamofireHTTPAdaptee.swift in Sources */,
 				8A27720C268E4ACC00D8878C /* GoogleSearchEngine.swift in Sources */,
 				8A2771BD268E4AAF00D8878C /* GoogleSearchEndpoint+AsyncAwait.swift in Sources */,
 				8A2771F2268E4AC600D8878C /* DnsRR.swift in Sources */,
 				8A27721D268E4ACF00D8878C /* OpenSearchParser.swift in Sources */,
 				8A2771D7268E4AB700D8878C /* GoogleDnsServer.swift in Sources */,
-				8A1A1CE727B1966E0052A2A3 /* AlamofireHTTPAdaptee.swift in Sources */,
+				8A1A1CE727B1966E0052A2A3 /* AlamofireHTTPRxAdaptee.swift in Sources */,
 				8ABDB0B627B269D500D6EDE7 /* HttpClient+Alamofire.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/catowser/catowser/Environment/HttpEnvironment.swift
+++ b/catowser/catowser/Environment/HttpEnvironment.swift
@@ -19,6 +19,12 @@ final class HttpEnvironment {
     let dnsAlReachability: AlamofireReachabilityAdaptee<GoogleDnsServer>
     let googleAlReachability: AlamofireReachabilityAdaptee<GoogleServer>
     
+    let googleClientRxSubscriber: GSearchClientRxSubscriber = .init()
+    let googleClientSubscriber: GSearchClientSubscriber = .init()
+    
+    let dnsClientRxSubscriber: GDNSJsonClientRxSubscriber = .init()
+    let dnsClientSubscriber: GDNSJsonClientSubscriber = .init()
+    
     private init() {
         let googleDNSserver = GoogleDnsServer()
         // swiftlint:disable:next force_unwrapping

--- a/catowser/catowser/Search/SearchSuggestionsViewController.swift
+++ b/catowser/catowser/Search/SearchSuggestionsViewController.swift
@@ -53,10 +53,6 @@ final class SearchSuggestionsViewController: UITableViewController {
     
     /// Not private to allow access from extension
     let googleClient: GoogleSuggestionsClient
-    /// 
-    let googleClientRxSubscriber: GSearchClientRxSubscriber = .init()
-    ///
-    let googleClientSubscriber: GSearchClientSubscriber = .init()
     
     private let waitingQueueName: String = .queueNameWith(suffix: "searchThrottle")
     
@@ -123,7 +119,8 @@ final class SearchSuggestionsViewController: UITableViewController {
                     let errorResult: SuggestionsResult = .failure(.zombieSelf)
                     return errorResult.publisher.eraseToAnyPublisher()
                 }
-                return self.googleClient.cGoogleSearchSuggestions(for: text, self.googleClientSubscriber)
+                let subscriber = HttpEnvironment.shared.googleClientSubscriber
+                return self.googleClient.cGoogleSearchSuggestions(for: text, subscriber)
             })
             .receive(on: DispatchQueue.main)
             .map { $0.textResults }
@@ -143,7 +140,8 @@ final class SearchSuggestionsViewController: UITableViewController {
                 guard let self = self else {
                     return .init(error: .zombieSelf)
                 }
-                return self.googleClient.googleSearchSuggestions(for: text, self.googleClientRxSubscriber)
+                let subscriber = HttpEnvironment.shared.googleClientRxSubscriber
+                return self.googleClient.googleSearchSuggestions(for: text, subscriber)
             })
             .observe(on: QueueScheduler.main)
             .startWithResult { [weak self] (result) in

--- a/catowser/catowser/Search/SearchSuggestionsViewController.swift
+++ b/catowser/catowser/Search/SearchSuggestionsViewController.swift
@@ -54,6 +54,8 @@ final class SearchSuggestionsViewController: UITableViewController {
     /// Not private to allow access from extension
     let googleClient: GoogleSuggestionsClient
     /// 
+    let googleClientRxSubscriber: GSearchClientRxSubscriber = .init()
+    ///
     let googleClientSubscriber: GSearchClientSubscriber = .init()
     
     private let waitingQueueName: String = .queueNameWith(suffix: "searchThrottle")
@@ -141,7 +143,7 @@ final class SearchSuggestionsViewController: UITableViewController {
                 guard let self = self else {
                     return .init(error: .zombieSelf)
                 }
-                return self.googleClient.googleSearchSuggestions(for: text, self.googleClientSubscriber)
+                return self.googleClient.googleSearchSuggestions(for: text, self.googleClientRxSubscriber)
             })
             .observe(on: QueueScheduler.main)
             .startWithResult { [weak self] (result) in

--- a/catowser/catowser/WebSite/TopSites/SiteCollectionViewCell.swift
+++ b/catowser/catowser/WebSite/TopSites/SiteCollectionViewCell.swift
@@ -19,8 +19,6 @@ final class SiteCollectionViewCell: UICollectionViewCell {
     
     @available(iOS 13.0, *)
     lazy var imageURLRequestCancellable: AnyCancellable? = nil
-    
-    let dnsClientSubscriber: GDNSJsonClientSubscriber = .init()
 
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/catowser/catowser/WebSite/TopSites/SiteCollectionViewCell.swift
+++ b/catowser/catowser/WebSite/TopSites/SiteCollectionViewCell.swift
@@ -20,7 +20,6 @@ final class SiteCollectionViewCell: UICollectionViewCell {
     @available(iOS 13.0, *)
     lazy var imageURLRequestCancellable: AnyCancellable? = nil
     
-    ///
     let dnsClientSubscriber: GDNSJsonClientSubscriber = .init()
 
     override func awakeFromNib() {

--- a/catowser/catowser/WebSite/TopSites/TopSitesViewController.swift
+++ b/catowser/catowser/WebSite/TopSites/TopSitesViewController.swift
@@ -100,9 +100,11 @@ extension SiteCollectionViewCell {
         faviconImageView.image = nil
 
         if #available(iOS 13.0, *) {
+            let subscriber = HttpEnvironment.shared.dnsClientSubscriber
+
             imageURLRequestCancellable?.cancel()
             let useDoH = FeatureManager.boolValue(of: .dnsOverHTTPSAvailable)
-            imageURLRequestCancellable = site.fetchFaviconURL(useDoH, dnsClientSubscriber)
+            imageURLRequestCancellable = site.fetchFaviconURL(useDoH, subscriber)
                 .receive(on: DispatchQueue.main)
                 .sink(receiveCompletion: { (completion) in
                     switch completion {

--- a/catowser/catowser/WebSite/WebViewController.swift
+++ b/catowser/catowser/WebSite/WebViewController.swift
@@ -48,6 +48,8 @@ final class WebViewController: BaseViewController {
     /// Not private to allow access from extension
     let dnsClient: GoogleDnsClient
     ///
+    let dnsClientRxSubscriber: GDNSJsonClientRxSubscriber = .init()
+    ///
     let dnsClientSubscriber: GDNSJsonClientSubscriber = .init()
     /// Was DoH used to load URL in WebView
     private(set) var dohUsed: Bool
@@ -302,7 +304,7 @@ final class WebViewController: BaseViewController {
     
     private func rxResolveDomainName(url: URL) {
         dnsRequestSubsciption?.dispose()
-        dnsRequestSubsciption = dnsClient.rxResolvedDomainName(in: url, dnsClientSubscriber)
+        dnsRequestSubsciption = dnsClient.rxResolvedDomainName(in: url, dnsClientRxSubscriber)
             .start(on: UIScheduler())
             .startWithResult({ [weak self] (result) in
                 guard let self = self else {

--- a/catowser/catowser/WebSite/WebViewController.swift
+++ b/catowser/catowser/WebSite/WebViewController.swift
@@ -47,10 +47,6 @@ final class WebViewController: BaseViewController {
     /// Http client to send DNS requests to unveal ip addresses of hosts to not show them, common for all web views
     /// Not private to allow access from extension
     let dnsClient: GoogleDnsClient
-    ///
-    let dnsClientRxSubscriber: GDNSJsonClientRxSubscriber = .init()
-    ///
-    let dnsClientSubscriber: GDNSJsonClientSubscriber = .init()
     /// Was DoH used to load URL in WebView
     private(set) var dohUsed: Bool
     /// State of web view
@@ -281,8 +277,10 @@ final class WebViewController: BaseViewController {
     
     @available(iOS 13.0, *)
     private func cResolveDomainName(url: URL) {
+        let subscriber = HttpEnvironment.shared.dnsClientSubscriber
+        
         dnsRequestCancellable?.cancel()
-        dnsRequestCancellable = dnsClient.resolvedDomainName(in: url, dnsClientSubscriber)
+        dnsRequestCancellable = dnsClient.resolvedDomainName(in: url, subscriber)
         .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { (completion) in
                 switch completion {
@@ -303,8 +301,9 @@ final class WebViewController: BaseViewController {
     }
     
     private func rxResolveDomainName(url: URL) {
+        let subscriber = HttpEnvironment.shared.dnsClientRxSubscriber
         dnsRequestSubsciption?.dispose()
-        dnsRequestSubsciption = dnsClient.rxResolvedDomainName(in: url, dnsClientRxSubscriber)
+        dnsRequestSubsciption = dnsClient.rxResolvedDomainName(in: url, subscriber)
             .start(on: UIScheduler())
             .startWithResult({ [weak self] (result) in
                 guard let self = self else {

--- a/catowser/catowser/WebTabs/TabPreviewCell.swift
+++ b/catowser/catowser/WebTabs/TabPreviewCell.swift
@@ -66,9 +66,6 @@ final class TabPreviewCell: UICollectionViewCell, ReusableItem {
     
     @available(iOS 13.0, *)
     private lazy var imageURLRequestCancellable: AnyCancellable? = nil
-    
-    ///
-    let dnsClientSubscriber: GDNSJsonClientSubscriber = .init()
 
     private let backgroundHolder: UIView = {
         let view = UIView()
@@ -201,9 +198,11 @@ final class TabPreviewCell: UICollectionViewCell, ReusableItem {
         }
         
         if #available(iOS 13.0, *) {
+            let subscriber = HttpEnvironment.shared.dnsClientSubscriber
+
             imageURLRequestCancellable?.cancel()
             let useDoH = FeatureManager.boolValue(of: .dnsOverHTTPSAvailable)
-            imageURLRequestCancellable = site.fetchFaviconURL(useDoH, dnsClientSubscriber)
+            imageURLRequestCancellable = site.fetchFaviconURL(useDoH, subscriber)
                 .receive(on: DispatchQueue.main)
                 .sink(receiveCompletion: { (completion) in
                     switch completion {

--- a/catowser/catowser/WebTabs/TabView.swift
+++ b/catowser/catowser/WebTabs/TabView.swift
@@ -44,9 +44,6 @@ final class TabView: UIView {
     
     weak var delegate: TabDelegate?
     
-    ///
-    let dnsClientSubscriber: GDNSJsonClientSubscriber = .init()
-    
     private lazy var centerBackground: UIView = {
         let centerBackground = UIView()
         centerBackground.translatesAutoresizingMaskIntoConstraints = false
@@ -218,9 +215,11 @@ private extension TabView {
         favicon.image = nil
         
         if #available(iOS 13.0, *) {
+            let subscriber = HttpEnvironment.shared.dnsClientSubscriber
+
             imageURLRequestCancellable?.cancel()
             let useDoH = FeatureManager.boolValue(of: .dnsOverHTTPSAvailable)
-            imageURLRequestCancellable = site.fetchFaviconURL(useDoH, dnsClientSubscriber)
+            imageURLRequestCancellable = site.fetchFaviconURL(useDoH, subscriber)
                 .receive(on: DispatchQueue.main)
                 .sink(receiveCompletion: { (completion) in
                     switch completion {


### PR DESCRIPTION
Checked that it compiles

response decoding stopped working, but I checked that it also doesn't work on main and it doesn't work mostly after first successful request. I'm suspecting that google API started rejecting auto complete requests even if I use firefox argument.