### PR TITLE
Search auto-complete UnitTests. Add SwiftyMocky dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ catowser/.gryphon
 local.properties
 CoreHttpKit/CoreHttpKit
 catowser/CoreBrowserTests/GeneratedMocks
+catowser/CoreCatowserTests/GeneratedMocks

--- a/README.md
+++ b/README.md
@@ -49,8 +49,11 @@ https://github.com/Alamofire/AlamofireImage
 Compile/Run time checks for Swift source code. 
 https://github.com/realm/SwiftLint
 ### Sourcery
-Used to generate simple mocks for the unit tests. Can't be used for the Swift protocols with associated types.
+Used to generate simple mocks. Can't be used for the Swift protocols with associated types.
 https://github.com/krzysztofzablocki/Sourcery
+### SwiftyMocky
+Used to generate complex mocks for the types and Swift protocols with associated types and constraints. 
+https://github.com/MakeAWishFoundation/SwiftyMocky
 
 ## Screenshots
 

--- a/catowser/.swiftlint.yml
+++ b/catowser/.swiftlint.yml
@@ -4,6 +4,7 @@ disabled_rules:
 excluded:
 - Carthage
 - Pods
+- CoreCatowserTests/GeneratedMocks
 
 identifier_name:
     min_length: 1 # warning

--- a/catowser/AutoMockable/AutoMockable.h
+++ b/catowser/AutoMockable/AutoMockable.h
@@ -1,0 +1,19 @@
+//
+//  AutoMockable.h
+//  AutoMockable
+//
+//  Created by Andrei Ermoshin on 10/27/22.
+//  Copyright © 2022 andreiermoshin. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for AutoMockable.
+FOUNDATION_EXPORT double AutoMockableVersionNumber;
+
+//! Project version string for AutoMockable.
+FOUNDATION_EXPORT const unsigned char AutoMockableVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <AutoMockable/PublicHeader.h>
+
+

--- a/catowser/AutoMockable/AutoMockable.swift
+++ b/catowser/AutoMockable/AutoMockable.swift
@@ -1,8 +1,8 @@
 //
 //  AutoMockable.swift
-//  CoreCatowser
+//  CoreBrowser
 //
-//  Created by Andrei Ermoshin on 10/18/22.
+//  Created by Andrei Ermoshin on 10/27/22.
 //  Copyright © 2022 andreiermoshin. All rights reserved.
 //
 

--- a/catowser/AutoMockable/AutoMockable.swift
+++ b/catowser/AutoMockable/AutoMockable.swift
@@ -9,3 +9,4 @@
 import Foundation
 
 public protocol AutoMockable { }
+public protocol AutoHashable {}

--- a/catowser/BrowserNetworking/Endpoints/DNSoverHTTPS/GoogleJSONDNSoHTTPsEndpoint.swift
+++ b/catowser/BrowserNetworking/Endpoints/DNSoverHTTPS/GoogleJSONDNSoHTTPsEndpoint.swift
@@ -13,10 +13,13 @@ import ReactiveSwift
 #if canImport(Combine)
 import Combine
 #endif
+import Alamofire
 
 /// https://tools.ietf.org/id/draft-ietf-doh-dns-over-https-02.txt
 
-public typealias GoogleDnsClient = RestClient<GoogleDnsServer, AlamofireReachabilityAdaptee<GoogleDnsServer>>
+public typealias GoogleDnsClient = RestClient<GoogleDnsServer,
+                                              AlamofireReachabilityAdaptee<GoogleDnsServer>,
+                                              JSONEncoding>
 
 typealias GDNSjsonEndpoint = Endpoint<GoogleDnsServer>
 public typealias GDNSjsonRxSignal = Signal<GoogleDNSOverJSONResponse, HttpError>.Observer

--- a/catowser/BrowserNetworking/Endpoints/DuckDuckGoAutocomplete/DuckDuckGoSearchEndpoint.swift
+++ b/catowser/BrowserNetworking/Endpoints/DuckDuckGoAutocomplete/DuckDuckGoSearchEndpoint.swift
@@ -11,9 +11,11 @@ import Combine
 import ReactiveSwift
 import CoreHttpKit
 import ReactiveHttpKit
+import Alamofire
 
 public typealias DDGoSuggestionsClient = RestClient<DuckDuckGoServer,
-                                                    AlamofireReachabilityAdaptee<DuckDuckGoServer>>
+                                                    AlamofireReachabilityAdaptee<DuckDuckGoServer>,
+                                                    JSONEncoding>
 typealias DDGoSuggestionsEndpoint = Endpoint<DuckDuckGoServer>
 
 extension Endpoint where S == DuckDuckGoServer {
@@ -31,7 +33,7 @@ extension Endpoint where S == DuckDuckGoServer {
             URLQueryItem(name: "q", value: query),
             URLQueryItem(name: "type", value: "list")
         ]
-        let headers: [HTTPHeader] = [.ContentType(type: .jsonsuggestions), .Accept(type: .jsonsuggestions)]
+        let headers: [CoreHttpKit.HTTPHeader] = [.ContentType(type: .jsonsuggestions), .Accept(type: .jsonsuggestions)]
         
         /**
          https://youtrack.jetbrains.com/issue/KT-44108

--- a/catowser/BrowserNetworking/Endpoints/Google/GoogleSearchEndpoint.swift
+++ b/catowser/BrowserNetworking/Endpoints/Google/GoogleSearchEndpoint.swift
@@ -13,8 +13,11 @@ import ReactiveSwift
 #if canImport(Combine)
 import Combine
 #endif
+import Alamofire
 
-public typealias GoogleSuggestionsClient = RestClient<GoogleServer, AlamofireReachabilityAdaptee<GoogleServer>>
+public typealias GoogleSuggestionsClient = RestClient<GoogleServer,
+                                                      AlamofireReachabilityAdaptee<GoogleServer>,
+                                                      JSONEncoding>
 typealias GSearchEndpoint = Endpoint<GoogleServer>
 public typealias GSearchRxSignal = Signal<GSearchSuggestionsResponse, HttpError>.Observer
 public typealias GSearchRxInterface = RxObserverWrapper<GSearchSuggestionsResponse,
@@ -45,7 +48,7 @@ extension Endpoint where S == GoogleServer {
             URLQueryItem(name: "client", value: "firefox")
         ]
         // Actually it's possible to get correct response even without any headers
-        let headers: [HTTPHeader] = [.ContentType(type: .jsonsuggestions), .Accept(type: .jsonsuggestions)]
+        let headers: [CoreHttpKit.HTTPHeader] = [.ContentType(type: .jsonsuggestions), .Accept(type: .jsonsuggestions)]
         
         let frozenEndpoint = GSearchEndpoint(
             httpMethod: .get,

--- a/catowser/CoreBrowser/History/DomainsHistory.swift
+++ b/catowser/CoreBrowser/History/DomainsHistory.swift
@@ -7,9 +7,13 @@
 //
 
 import CoreHttpKit
+import AutoMockable
+
+public protocol KnownDomainsSource: AutoMockable {
+    func domainNames(whereURLContains filter: String) -> [String]
+}
 
 /// Interface for domain checks
 public protocol DomainsHistory {
     func remember(host: CoreHttpKit.Host)
-    func domainNames(whereURLContains filter: String) -> [String]
 }

--- a/catowser/CoreBrowser/History/InMemoryDomainSearchProvider.swift
+++ b/catowser/CoreBrowser/History/InMemoryDomainSearchProvider.swift
@@ -34,15 +34,17 @@ public final class InMemoryDomainSearchProvider {
 }
 
 extension InMemoryDomainSearchProvider: DomainsHistory {
-    public func domainNames(whereURLContains filter: String) -> [String] {
-        let words: [String] = storage.findWordsWithPrefix(prefix: filter)
-        return words
-    }
-
     public func remember(host: CoreHttpKit.Host) {
         storage.insert(word: host.rawString)
         if let withoutWww = host.rawString.withoutPrefix("www.") {
             storage.insert(word: withoutWww)
         }
+    }
+}
+
+extension InMemoryDomainSearchProvider: KnownDomainsSource {
+    public func domainNames(whereURLContains filter: String) -> [String] {
+        let words: [String] = storage.findWordsWithPrefix(prefix: filter)
+        return words
     }
 }

--- a/catowser/CoreBrowser/Tabs/TabSelectionStrategy.swift
+++ b/catowser/CoreBrowser/Tabs/TabSelectionStrategy.swift
@@ -7,15 +7,14 @@
 //
 
 import Foundation
+import AutoMockable
 
-// sourcery: AutoMockable
-public protocol IndexSelectionContext {
+public protocol IndexSelectionContext: AutoMockable {
     var collectionLastIndex: Int { get }
     var currentlySelectedIndex: Int { get }
 }
 
-// sourcery: AutoMockable
-public protocol TabSelectionStrategy {
+public protocol TabSelectionStrategy: AutoMockable {
     /**
      A Tab selection strategy (Compositor) defines the algorithms of tab selection in specific cases
      - when tab was removed and need to select another

--- a/catowser/CoreBrowser/Tabs/TabsStates.swift
+++ b/catowser/CoreBrowser/Tabs/TabsStates.swift
@@ -7,9 +7,9 @@
 //
 
 import Foundation
+import AutoMockable
 
-// sourcery: AutoMockable
-public protocol TabsStates {
+public protocol TabsStates: AutoMockable {
     var addPosition: AddedTabPosition { get }
     var contentState: Tab.ContentType { get }
     var addSpeed: TabAddSpeed { get }

--- a/catowser/CoreBrowser/Tabs/TabsStoragable.swift
+++ b/catowser/CoreBrowser/Tabs/TabsStoragable.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 import ReactiveSwift
+import AutoMockable
 
-// sourcery: AutoMockable
-public protocol TabsStoragable {
+public protocol TabsStoragable: AutoMockable {
     /// Defines human redable name for Int if it is describes index.
     /// e.g. implementation could use Index type instead.
     typealias TabIndex = Int

--- a/catowser/CoreCatowser/SearchViewModel/Autocomplete/RestClientContext.swift
+++ b/catowser/CoreCatowser/SearchViewModel/Autocomplete/RestClientContext.swift
@@ -18,24 +18,30 @@ import AutoMockable
 // swiftlint:disable comment_spacing
 //sourcery: associatedtype = "R: ResponseType"
 //sourcery: associatedtype = "S: ServerDescription"
-//sourcery: associatedtype = "RAdapter: NetworkReachabilityAdapter"
+//sourcery: associatedtype = "RA: NetworkReachabilityAdapter where RA.Server == S"
 //sourcery: associatedtype = "E: JSONRequestEncodable"
+//sourcery: associatedtype = "C: RestInterface where C.Reachability == RA, C.Encoder == E"
 //sourcery: typealias = "Response = R"
 //sourcery: typealias = "Server = S"
-//sourcery: typealias = "ReachabilityAdapter = RAdapter where RAdapter.Server == Server"
+//sourcery: typealias = "ReachabilityAdapter = RA"
 //sourcery: typealias = "Encoder = E"
+//sourcery: typealias = "Client = C"
 public protocol RestClientContext: AnyObject, AutoMockable {
+    // swiftlint:enable comment_spacing
     associatedtype Response: ResponseType
     associatedtype Server: ServerDescription
     associatedtype ReachabilityAdapter: NetworkReachabilityAdapter where ReachabilityAdapter.Server == Server
     associatedtype Encoder: JSONRequestEncodable
     associatedtype Client: RestInterface where Client.Reachability == ReachabilityAdapter, Client.Encoder == Encoder
     
+    /// Alias for a ReactiveSwift type with specific types in place of generics
     typealias Observer = Signal<Response, HttpError>.Observer
+    /// Alias for a real type, no need to hide it under protocol
     typealias ObserverWrapper = RxObserverWrapper<Response, Server, Observer>
+    /// Alias for a real type, no need to hide it under protocol
     typealias HttpKitRxSubscriber = RxSubscriber<Response, Server, ObserverWrapper>
+    /// Alias for a real type, no need to hide it under protocol
     typealias HttpKitSubscriber = Sub<Response, Server>
-    // swiftlint:enable comment_spacing
     
     var client: Client { get }
     var rxSubscriber: HttpKitRxSubscriber { get }

--- a/catowser/CoreCatowser/SearchViewModel/Autocomplete/RestClientContext.swift
+++ b/catowser/CoreCatowser/SearchViewModel/Autocomplete/RestClientContext.swift
@@ -22,19 +22,19 @@ import AutoMockable
 //sourcery: associatedtype = "E: JSONRequestEncodable"
 //sourcery: typealias = "Response = R"
 //sourcery: typealias = "Server = S"
-//sourcery: typealias = "ReachabilityAdapter = RAdapter where ReachabilityAdapter.Server == Server"
+//sourcery: typealias = "ReachabilityAdapter = RAdapter where RAdapter.Server == Server"
 //sourcery: typealias = "Encoder = E"
-public protocol RestClientContext: AnyObject, AutoMockable where ReachabilityAdapter.Server == Server {
+public protocol RestClientContext: AnyObject, AutoMockable {
     associatedtype Response: ResponseType
     associatedtype Server: ServerDescription
-    associatedtype ReachabilityAdapter: NetworkReachabilityAdapter
+    associatedtype ReachabilityAdapter: NetworkReachabilityAdapter where ReachabilityAdapter.Server == Server
     associatedtype Encoder: JSONRequestEncodable
+    associatedtype Client: RestInterface where Client.Reachability == ReachabilityAdapter, Client.Encoder == Encoder
     
     typealias Observer = Signal<Response, HttpError>.Observer
     typealias ObserverWrapper = RxObserverWrapper<Response, Server, Observer>
     typealias HttpKitRxSubscriber = RxSubscriber<Response, Server, ObserverWrapper>
     typealias HttpKitSubscriber = Sub<Response, Server>
-    typealias Client = RestClient<Server, ReachabilityAdapter, Encoder>
     // swiftlint:enable comment_spacing
     
     var client: Client { get }

--- a/catowser/CoreCatowser/SearchViewModel/Autocomplete/RestClientContext.swift
+++ b/catowser/CoreCatowser/SearchViewModel/Autocomplete/RestClientContext.swift
@@ -16,14 +16,18 @@ import BrowserNetworking
 import AutoMockable
 
 // swiftlint:disable comment_spacing
-//sourcery: associatedtype = "Response: ResponseType"
-//sourcery: associatedtype = "Server: ServerDescription"
-//sourcery: associatedtype = "ReachabilityAdapter: NetworkReachabilityAdapter"
-//sourcery: associatedtype = "Encoder: JSONRequestEncodable"
-public protocol RestClientContext: AnyObject, AutoMockable {
+//sourcery: associatedtype = "R: ResponseType"
+//sourcery: associatedtype = "S: ServerDescription"
+//sourcery: associatedtype = "RAdapter: NetworkReachabilityAdapter"
+//sourcery: associatedtype = "E: JSONRequestEncodable"
+//sourcery: typealias = "Response = R"
+//sourcery: typealias = "Server = S"
+//sourcery: typealias = "ReachabilityAdapter = RAdapter where ReachabilityAdapter.Server == Server"
+//sourcery: typealias = "Encoder = E"
+public protocol RestClientContext: AnyObject, AutoMockable where ReachabilityAdapter.Server == Server {
     associatedtype Response: ResponseType
     associatedtype Server: ServerDescription
-    associatedtype ReachabilityAdapter: NetworkReachabilityAdapter where ReachabilityAdapter.Server == Server
+    associatedtype ReachabilityAdapter: NetworkReachabilityAdapter
     associatedtype Encoder: JSONRequestEncodable
     
     typealias Observer = Signal<Response, HttpError>.Observer

--- a/catowser/CoreCatowser/SearchViewModel/Autocomplete/RestClientContext.swift
+++ b/catowser/CoreCatowser/SearchViewModel/Autocomplete/RestClientContext.swift
@@ -15,16 +15,23 @@ import ReactiveHttpKit
 import BrowserNetworking
 import AutoMockable
 
+// swiftlint:disable comment_spacing
+//sourcery: associatedtype = "Response: ResponseType"
+//sourcery: associatedtype = "Server: ServerDescription"
+//sourcery: associatedtype = "ReachabilityAdapter: NetworkReachabilityAdapter"
+//sourcery: associatedtype = "Encoder: JSONRequestEncodable"
 public protocol RestClientContext: AnyObject, AutoMockable {
     associatedtype Response: ResponseType
     associatedtype Server: ServerDescription
     associatedtype ReachabilityAdapter: NetworkReachabilityAdapter where ReachabilityAdapter.Server == Server
+    associatedtype Encoder: JSONRequestEncodable
     
     typealias Observer = Signal<Response, HttpError>.Observer
     typealias ObserverWrapper = RxObserverWrapper<Response, Server, Observer>
     typealias HttpKitRxSubscriber = RxSubscriber<Response, Server, ObserverWrapper>
     typealias HttpKitSubscriber = Sub<Response, Server>
-    typealias Client = RestClient<Server, ReachabilityAdapter>
+    typealias Client = RestClient<Server, ReachabilityAdapter, Encoder>
+    // swiftlint:enable comment_spacing
     
     var client: Client { get }
     var rxSubscriber: HttpKitRxSubscriber { get }

--- a/catowser/CoreCatowser/SearchViewModel/Autocomplete/RestClientContext.swift
+++ b/catowser/CoreCatowser/SearchViewModel/Autocomplete/RestClientContext.swift
@@ -13,6 +13,7 @@ import Combine
 import CoreHttpKit
 import ReactiveHttpKit
 import BrowserNetworking
+import AutoMockable
 
 public protocol RestClientContext: AnyObject, AutoMockable {
     associatedtype Response: ResponseType

--- a/catowser/CoreCatowser/SearchViewModel/Autocomplete/SearchAutocompleteStrategy.swift
+++ b/catowser/CoreCatowser/SearchViewModel/Autocomplete/SearchAutocompleteStrategy.swift
@@ -10,6 +10,7 @@ import Foundation
 import HttpKit
 import ReactiveSwift
 import Combine
+import AutoMockable
 
 public protocol SearchAutocompleteStrategy: AnyObject, AutoMockable {
     associatedtype Context: RestClientContext

--- a/catowser/CoreCatowser/SearchViewModel/Autocomplete/SearchAutocompleteStrategy.swift
+++ b/catowser/CoreCatowser/SearchViewModel/Autocomplete/SearchAutocompleteStrategy.swift
@@ -12,7 +12,11 @@ import ReactiveSwift
 import Combine
 import AutoMockable
 
+// swiftlint:disable comment_spacing
+//sourcery: associatedtype = "Context: RestClientContext"
 public protocol SearchAutocompleteStrategy: AnyObject, AutoMockable {
+    // swiftlint:enable comment_spacing
+    
     associatedtype Context: RestClientContext
     
     init(_ context: Context)

--- a/catowser/CoreCatowser/SearchViewModel/Autocomplete/SearchSuggestionsResponse.swift
+++ b/catowser/CoreCatowser/SearchViewModel/Autocomplete/SearchSuggestionsResponse.swift
@@ -23,4 +23,9 @@ public struct SearchSuggestionsResponse {
         queryText = ddgoResponse.queryText
         textResults = ddgoResponse.textResults
     }
+    
+    init(_ query: String, _ results: [String]) {
+        queryText = query
+        textResults = results
+    }
 }

--- a/catowser/CoreCatowser/SearchViewModel/Autocomplete/SpecificStrategies/DDGoAutocompleteStrategy.swift
+++ b/catowser/CoreCatowser/SearchViewModel/Autocomplete/SpecificStrategies/DDGoAutocompleteStrategy.swift
@@ -18,6 +18,7 @@ public final class DDGoContext: RestClientContext {
     public typealias Server = DuckDuckGoServer
     public typealias ReachabilityAdapter = AlamofireReachabilityAdaptee<Server>
     public typealias Encoder = JSONEncoding
+    public typealias Client = RestClient<Server, ReachabilityAdapter, Encoder>
     
     public let client: Client
     public let rxSubscriber: HttpKitRxSubscriber

--- a/catowser/CoreCatowser/SearchViewModel/Autocomplete/SpecificStrategies/DDGoAutocompleteStrategy.swift
+++ b/catowser/CoreCatowser/SearchViewModel/Autocomplete/SpecificStrategies/DDGoAutocompleteStrategy.swift
@@ -11,11 +11,13 @@ import BrowserNetworking
 import ReactiveSwift
 import Combine
 import HttpKit
+import Alamofire
 
 public final class DDGoContext: RestClientContext {
     public typealias Response = DDGoSuggestionsResponse
     public typealias Server = DuckDuckGoServer
     public typealias ReachabilityAdapter = AlamofireReachabilityAdaptee<Server>
+    public typealias Encoder = JSONEncoding
     
     public let client: Client
     public let rxSubscriber: HttpKitRxSubscriber

--- a/catowser/CoreCatowser/SearchViewModel/Autocomplete/SpecificStrategies/GoogleAutocompleteStrategy.swift
+++ b/catowser/CoreCatowser/SearchViewModel/Autocomplete/SpecificStrategies/GoogleAutocompleteStrategy.swift
@@ -11,11 +11,13 @@ import BrowserNetworking
 import ReactiveSwift
 import Combine
 import HttpKit
+import Alamofire
 
 public final class GoogleContext: RestClientContext {
     public typealias Response = GSearchSuggestionsResponse
     public typealias Server = GoogleServer
     public typealias ReachabilityAdapter = AlamofireReachabilityAdaptee<Server>
+    public typealias Encoder = JSONEncoding
     
     public let client: Client
     public let rxSubscriber: HttpKitRxSubscriber

--- a/catowser/CoreCatowser/SearchViewModel/Autocomplete/SpecificStrategies/GoogleAutocompleteStrategy.swift
+++ b/catowser/CoreCatowser/SearchViewModel/Autocomplete/SpecificStrategies/GoogleAutocompleteStrategy.swift
@@ -18,6 +18,7 @@ public final class GoogleContext: RestClientContext {
     public typealias Server = GoogleServer
     public typealias ReachabilityAdapter = AlamofireReachabilityAdaptee<Server>
     public typealias Encoder = JSONEncoding
+    public typealias Client = RestClient<Server, ReachabilityAdapter, Encoder>
     
     public let client: Client
     public let rxSubscriber: HttpKitRxSubscriber

--- a/catowser/CoreCatowser/SearchViewModel/SearchSuggestionsViewModelImpl.swift
+++ b/catowser/CoreCatowser/SearchViewModel/SearchSuggestionsViewModelImpl.swift
@@ -11,10 +11,12 @@ import ReactiveSwift
 import Combine
 import FeaturesFlagsKit
 import CoreBrowser
+import AutoMockable
 
 /// This is only needed now to not have a direct dependency on FutureManager
-public protocol SearchViewContext: AnyObject {
-    func appAsyncApiTypeValue() -> AsyncApiType
+public protocol SearchViewContext: AutoMockable {
+    var appAsyncApiTypeValue: AsyncApiType { get }
+    var knownDomainsStorage: KnownDomainsSource { get }
 }
 
 public final class SearchSuggestionsViewModelImpl<Strategy> where Strategy: SearchAutocompleteStrategy {
@@ -58,9 +60,9 @@ public final class SearchSuggestionsViewModelImpl<Strategy> where Strategy: Sear
 
 extension SearchSuggestionsViewModelImpl: SearchSuggestionsViewModel {
     public func fetchSuggestions(_ query: String) {
-        let domainNames = InMemoryDomainSearchProvider.shared.domainNames(whereURLContains: query)
+        let domainNames = searchContext.knownDomainsStorage.domainNames(whereURLContains: query)
         
-        let apiType = searchContext.appAsyncApiTypeValue()
+        let apiType = searchContext.appAsyncApiTypeValue
         switch apiType {
         case .reactive:
             rxState.value = .knownDomainsLoaded(domainNames)

--- a/catowser/CoreCatowser/WebViewModel/DNSResolving/SpecificStrategies/GoogleDNSStrategy.swift
+++ b/catowser/CoreCatowser/WebViewModel/DNSResolving/SpecificStrategies/GoogleDNSStrategy.swift
@@ -18,6 +18,7 @@ public final class GoogleDNSContext: RestClientContext {
     public typealias Server = GoogleDnsServer
     public typealias ReachabilityAdapter = AlamofireReachabilityAdaptee<Server>
     public typealias Encoder = JSONEncoding
+    public typealias Client = RestClient<Server, ReachabilityAdapter, Encoder>
     
     public let client: Client
     public let rxSubscriber: HttpKitRxSubscriber

--- a/catowser/CoreCatowser/WebViewModel/DNSResolving/SpecificStrategies/GoogleDNSStrategy.swift
+++ b/catowser/CoreCatowser/WebViewModel/DNSResolving/SpecificStrategies/GoogleDNSStrategy.swift
@@ -11,11 +11,13 @@ import BrowserNetworking
 import ReactiveSwift
 import Combine
 import HttpKit
+import Alamofire
 
 public final class GoogleDNSContext: RestClientContext {
     public typealias Response = GoogleDNSOverJSONResponse
     public typealias Server = GoogleDnsServer
     public typealias ReachabilityAdapter = AlamofireReachabilityAdaptee<Server>
+    public typealias Encoder = JSONEncoding
     
     public let client: Client
     public let rxSubscriber: HttpKitRxSubscriber

--- a/catowser/CoreCatowserTests/Mocks/MockedRestInterface.swift
+++ b/catowser/CoreCatowserTests/Mocks/MockedRestInterface.swift
@@ -1,0 +1,26 @@
+//
+//  MockedRestInterface.swift
+//  CoreCatowserTests
+//
+//  Created by Andrei Ermoshin on 10/30/22.
+//  Copyright © 2022 andreiermoshin. All rights reserved.
+//
+
+import HttpKit
+import CoreHttpKit
+
+final class MockedRestInterface<S: ServerDescription,
+                                R: NetworkReachabilityAdapter,
+                                E: JSONRequestEncodable>: RestInterface where R.Server == S {
+    typealias Server = S
+    typealias Reachability = R
+    typealias Encoder = E
+    
+    let server: Server
+    let jsonEncoder: Encoder
+    
+    init(server: S, jsonEncoder: E, reachability: R, httpTimeout: TimeInterval = 10) {
+        self.server = server
+        self.jsonEncoder = jsonEncoder
+    }
+}

--- a/catowser/CoreCatowserTests/Mocks/RestClientContextMocks.swift
+++ b/catowser/CoreCatowserTests/Mocks/RestClientContextMocks.swift
@@ -12,6 +12,7 @@ final class MockedDNSContext: RestClientContext {
     public typealias Response = MockedDNSResponse
     public typealias Server = MockedGoodDnsServer
     public typealias ReachabilityAdapter = MockedReachabilityAdaptee<Server>
+    public typealias Encoder = MockedGoodJSONEncoding
     
     public let client: Client
     public let rxSubscriber: HttpKitRxSubscriber

--- a/catowser/CoreCatowserTests/Mocks/RestClientContextMocks.swift
+++ b/catowser/CoreCatowserTests/Mocks/RestClientContextMocks.swift
@@ -13,6 +13,7 @@ final class MockedDNSContext: RestClientContext {
     public typealias Server = MockedGoodDnsServer
     public typealias ReachabilityAdapter = MockedReachabilityAdaptee<Server>
     public typealias Encoder = MockedGoodJSONEncoding
+    public typealias Client = MockedRestInterface<Server, ReachabilityAdapter, Encoder>
     
     public let client: Client
     public let rxSubscriber: HttpKitRxSubscriber

--- a/catowser/CoreCatowserTests/Mocks/ServerDescriptionMocks.swift
+++ b/catowser/CoreCatowserTests/Mocks/ServerDescriptionMocks.swift
@@ -8,7 +8,7 @@
 
 import CoreHttpKit
 
-class MockedGoodDnsServer: ServerDescription {
+final class MockedGoodDnsServer: ServerDescription {
     convenience init() {
         // swiftlint:disable:next force_try
         let host = try! Host(input: "www.example.com")

--- a/catowser/CoreCatowserTests/SearchSuggestionsVMCombineTests.swift
+++ b/catowser/CoreCatowserTests/SearchSuggestionsVMCombineTests.swift
@@ -10,10 +10,13 @@ import XCTest
 @testable import CoreCatowser
 
 final class SearchSuggestionsVMCombineTests: XCTestCase {
-
+    private let rxSubscriber: HttpKitRxSubscriber = .init()
+    private let subscriber: HttpKitSubscriber = .init()
+    
     func testExample() throws {
-        // let contextMock: RestClientContextMock = .init(<#T##Client#>, <#T##HttpKitRxSubscriber#>, <#T##HttpKitSubscriber#>)
-        // let stratMock: SearchAutocompleteStrategyMock = .init(<#T##Context#>)
+        let restClient: RestInterfaceMock = .init()
+        let contextMock: RestClientContextMock = .init(restClient, rxSubscriber, subscriber)
+        let strategyMock: SearchAutocompleteStrategyMock = .init(contextMock)
     }
 
 }

--- a/catowser/CoreCatowserTests/SearchSuggestionsVMCombineTests.swift
+++ b/catowser/CoreCatowserTests/SearchSuggestionsVMCombineTests.swift
@@ -1,0 +1,121 @@
+//
+//  SearchSuggestionsVMCombineTests.swift
+//  CoreCatowserTests
+//
+//  Created by Andrei Ermoshin on 11/4/22.
+//  Copyright © 2022 andreiermoshin. All rights reserved.
+//
+
+import XCTest
+@testable import CoreCatowser
+import CoreHttpKit
+import HttpKit
+import ReactiveHttpKit
+import ReactiveSwift
+import Combine
+import BrowserNetworking
+import SwiftyMocky
+
+final class SearchSuggestionsVMCombineTests: XCTestCase {
+    private var goodServerMock: MockedGoodDnsServer!
+    private var goodJsonEncodingMock: MockedGoodJSONEncoding!
+    private var reachabilityMock: NetworkReachabilityAdapterMock<MockedGoodDnsServer>!
+    typealias Observer = Signal<MockedGoodResponse, HttpError>.Observer
+    typealias ObserverWrapper = RxObserverWrapper<MockedGoodResponse, MockedGoodDnsServer, Observer>
+    private var subscriber: Sub<MockedGoodResponse, MockedGoodDnsServer>!
+    private var rxSubscriber: RxSubscriber<MockedGoodResponse, MockedGoodDnsServer, ObserverWrapper>!
+    private var goodRestClient: RestInterfaceMock<MockedGoodDnsServer,
+                                                  NetworkReachabilityAdapterMock<MockedGoodDnsServer>,
+                                                  MockedGoodJSONEncoding>!
+    private lazy var goodContextMock: RestClientContextMock = .init(goodRestClient, rxSubscriber, subscriber)
+    private lazy var strategyMock: SearchAutocompleteStrategyMock = .init(goodContextMock)
+    private var searchViewContextMock: SearchViewContextMock!
+    private var knownDomainsStorageMock: KnownDomainsSourceMock!
+    private var cancellables: Set<AnyCancellable>!
+    
+    private var combineFetchSuggestionsCounter = 0
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        cancellables = []
+        goodServerMock = .init()
+        goodJsonEncodingMock = .init()
+        // swiftlint:disable:next force_unwrapping
+        reachabilityMock = NetworkReachabilityAdapterMock(server: goodServerMock)!
+        subscriber = .init()
+        rxSubscriber = .init()
+        goodRestClient = .init(server: goodServerMock,
+                               jsonEncoder: goodJsonEncodingMock,
+                               reachability: reachabilityMock,
+                               httpTimeout: 10)
+        goodContextMock = .init(goodRestClient, rxSubscriber, subscriber)
+        searchViewContextMock = .init()
+        knownDomainsStorageMock = .init()
+        strategyMock = .init(goodContextMock)
+        combineFetchSuggestionsCounter = 0
+    }
+
+    func testVMInitAndSuggestionsFetch() throws {
+        let vm: SearchSuggestionsViewModelImpl = .init(strategyMock, searchViewContextMock)
+        XCTAssertEqual(vm.state, .waitingForQuery)
+        Given(searchViewContextMock, .appAsyncApiTypeValue(getter: .combine))
+        let input1 = "g"
+        let input2 = "o"
+        let expected1 = ["google", "gmail"]
+        let known1 = ["google.com", "gmail.com"]
+        let expected2 = ["opennet com", "overwatch"]
+        let known2 = ["opennet.com", "blizzard.com"]
+        let promiseValue1: SearchSuggestionsResponse = .init(input1, expected1)
+        let responsePublisher1: AnyPublisher<SearchSuggestionsResponse, HttpError> = Future
+            .success(promiseValue1)
+            .eraseToAnyPublisher()
+        let promiseValue2: SearchSuggestionsResponse = .init(input2, expected2)
+        let responsePublisher2: AnyPublisher<SearchSuggestionsResponse, HttpError> = Future
+            .success(promiseValue2)
+            .eraseToAnyPublisher()
+        combineFetchSuggestionsCounter = 5
+        let expectation1 = XCTestExpectation(description: "Suggestions were not received v1")
+        let expectation2 = XCTestExpectation(description: "Suggestions were not received v2")
+        let cancellable = vm.combineState.sink { state in
+            if self.combineFetchSuggestionsCounter == 5 {
+                XCTAssertEqual(state, .waitingForQuery)
+                self.combineFetchSuggestionsCounter -= 1
+            } else if self.combineFetchSuggestionsCounter == 4 {
+                XCTAssertEqual(state, .knownDomainsLoaded(known1))
+                self.combineFetchSuggestionsCounter -= 1
+            } else if self.combineFetchSuggestionsCounter == 3 {
+                XCTAssertEqual(state, .everythingLoaded(known1, expected1))
+                self.combineFetchSuggestionsCounter -= 1
+                expectation1.fulfill()
+            } else if self.combineFetchSuggestionsCounter == 2 {
+                XCTAssertEqual(state, .knownDomainsLoaded(known2))
+                self.combineFetchSuggestionsCounter -= 1
+            } else if self.combineFetchSuggestionsCounter == 1 {
+                XCTAssertEqual(state, .everythingLoaded(known2, expected2))
+                self.combineFetchSuggestionsCounter -= 1
+                expectation2.fulfill()
+            } else {
+                XCTAssert(false, "Not expected state change")
+            }
+        }
+        cancellables.insert(cancellable)
+        
+        Given(strategyMock, .suggestionsPublisher(for: .value(input1), willProduce: { stubber in
+            stubber.return(responsePublisher1)
+        }))
+        Given(searchViewContextMock, .knownDomainsStorage(getter: knownDomainsStorageMock))
+        Given(knownDomainsStorageMock, .domainNames(whereURLContains: .value(input1), willReturn: known1))
+        vm.fetchSuggestions(input1)
+        XCTAssertEqual(vm.state, .waitingForQuery)
+        wait(for: [expectation1], timeout: 1)
+        Given(strategyMock, .suggestionsPublisher(for: .value(input2), willProduce: { stubber in
+            stubber.return(responsePublisher2)
+        }))
+        Given(searchViewContextMock, .knownDomainsStorage(getter: knownDomainsStorageMock))
+        Given(knownDomainsStorageMock, .domainNames(whereURLContains: .value(input2), willReturn: known2))
+        vm.fetchSuggestions(input2)
+        XCTAssertEqual(vm.state, .waitingForQuery)
+        wait(for: [expectation2], timeout: 1)
+    }
+
+}

--- a/catowser/CoreCatowserTests/SearchSuggestionsVMCombineTests.swift
+++ b/catowser/CoreCatowserTests/SearchSuggestionsVMCombineTests.swift
@@ -11,13 +11,9 @@ import XCTest
 
 final class SearchSuggestionsVMCombineTests: XCTestCase {
 
-    override func setUpWithError() throws {
-    }
-
-    override func tearDownWithError() throws {
-    }
-
     func testExample() throws {
+        // let contextMock: RestClientContextMock = .init(<#T##Client#>, <#T##HttpKitRxSubscriber#>, <#T##HttpKitSubscriber#>)
+        // let stratMock: SearchAutocompleteStrategyMock = .init(<#T##Context#>)
     }
 
 }

--- a/catowser/CoreCatowserTests/SearchSuggestionsVMCombineTests.swift
+++ b/catowser/CoreCatowserTests/SearchSuggestionsVMCombineTests.swift
@@ -8,15 +8,45 @@
 
 import XCTest
 @testable import CoreCatowser
+import CoreHttpKit
+import HttpKit
+import ReactiveHttpKit
+import ReactiveSwift
+import BrowserNetworking
+
+struct MockedGoodResponse: ResponseType {
+    static var successCodes: [Int] {
+        return [200]
+    }
+}
 
 final class SearchSuggestionsVMCombineTests: XCTestCase {
-    private let rxSubscriber: HttpKitRxSubscriber = .init()
-    private let subscriber: HttpKitSubscriber = .init()
+    let goodServerMock: MockedGoodDnsServer = .init()
+    let goodJsonEncodingMock: MockedGoodJSONEncoding = .init()
+    // swiftlint:disable:next force_unwrapping
+    lazy var reachabilityMock = NetworkReachabilityAdapterMock(server: goodServerMock)!
+    typealias Observer = Signal<MockedGoodResponse, HttpError>.Observer
+    typealias ObserverWrapper = RxObserverWrapper<MockedGoodResponse, MockedGoodDnsServer, Observer>
+    private let subscriber: Sub<MockedGoodResponse, MockedGoodDnsServer> = .init()
+    private let rxSubscriber: RxSubscriber<MockedGoodResponse, MockedGoodDnsServer, ObserverWrapper> = .init()
     
-    func testExample() throws {
-        let restClient: RestInterfaceMock = .init()
-        let contextMock: RestClientContextMock = .init(restClient, rxSubscriber, subscriber)
+    func testWebSearchAutocomplete() throws {
+        let restClient: RestInterfaceMock = .init(server: goodServerMock,
+                                                  jsonEncoder: goodJsonEncodingMock,
+                                                  reachability: reachabilityMock,
+                                                  httpTimeout: 10)
+        let contextMock = RestClientContextMock(restClient, rxSubscriber, subscriber)
         let strategyMock: SearchAutocompleteStrategyMock = .init(contextMock)
+        
+        let autoCompleteFacade: WebSearchAutocomplete = .init(strategyMock)
+        let producer = autoCompleteFacade.rxFetchSuggestions("how to use")
+        let expected = ["how to use Swift", "how to use Kotlin"]
+        let expectationRxSuggestionFail = XCTestExpectation(description: "Suggestions were not received")
+        producer.startWithResult { result in
+            expectationRxSuggestionFail.fulfill()
+            // swiftlint:disable:next force_try
+            let received = try! result.get()
+            XCTAssertEqual(received, expected)
+        }
     }
-
 }

--- a/catowser/CoreCatowserTests/WebViewVMCombineTests.swift
+++ b/catowser/CoreCatowserTests/WebViewVMCombineTests.swift
@@ -215,7 +215,6 @@ final class WebViewVMCombineTests: XCTestCase {
         XCTAssertEqual(vm.state, .viewing(settings, urlInfoV1), "New url is expected")
     }
     
-    // swiftlint:disable:next function_body_length
     func testGoForward() throws {
         let vm: WebViewModelImpl = WebViewModelImpl(goodDnsStrategy, exampleSite, minimumWebViewContext)
         vm.load()

--- a/catowser/CoreCatowserTests/WebViewVMCombineTests.swift
+++ b/catowser/CoreCatowserTests/WebViewVMCombineTests.swift
@@ -18,7 +18,7 @@ final class WebViewVMCombineTests: XCTestCase {
     let goodJsonEncodingMock: MockedGoodJSONEncoding = .init()
     // swiftlint:disable:next force_unwrapping
     lazy var goodReachabilityMock: MockedReachabilityAdaptee = .init(server: goodServerMock)!
-    lazy var goodDnsClient: RestClient<MockedGoodDnsServer, MockedReachabilityAdaptee> = {
+    lazy var goodDnsClient: RestClient<MockedGoodDnsServer, MockedReachabilityAdaptee, MockedGoodJSONEncoding> = {
         .init(server: goodServerMock, jsonEncoder: goodJsonEncodingMock, reachability: goodReachabilityMock)
     }()
     let rxSubscriber: MockedDNSContext.HttpKitRxSubscriber = .init()

--- a/catowser/CoreCatowserTests/WebViewVMCombineTests.swift
+++ b/catowser/CoreCatowserTests/WebViewVMCombineTests.swift
@@ -18,7 +18,7 @@ final class WebViewVMCombineTests: XCTestCase {
     let goodJsonEncodingMock: MockedGoodJSONEncoding = .init()
     // swiftlint:disable:next force_unwrapping
     lazy var goodReachabilityMock: MockedReachabilityAdaptee = .init(server: goodServerMock)!
-    lazy var goodDnsClient: RestClient<MockedGoodDnsServer, MockedReachabilityAdaptee, MockedGoodJSONEncoding> = {
+    lazy var goodDnsClient: MockedRestInterface<MockedGoodDnsServer, MockedReachabilityAdaptee, MockedGoodJSONEncoding> = {
         .init(server: goodServerMock, jsonEncoder: goodJsonEncodingMock, reachability: goodReachabilityMock)
     }()
     let rxSubscriber: MockedDNSContext.HttpKitRxSubscriber = .init()

--- a/catowser/CoreCatowserTests/WebViewVmDNSoverHTTPSTests.swift
+++ b/catowser/CoreCatowserTests/WebViewVmDNSoverHTTPSTests.swift
@@ -17,7 +17,7 @@ final class WebViewVmDNSoverHTTPSTests: XCTestCase {
     let goodJsonEncodingMock: MockedGoodJSONEncoding = .init()
     // swiftlint:disable:next force_unwrapping
     lazy var goodReachabilityMock: MockedReachabilityAdaptee = .init(server: goodServerMock)!
-    lazy var goodDnsClient: RestClient<MockedGoodDnsServer, MockedReachabilityAdaptee> = {
+    lazy var goodDnsClient: RestClient<MockedGoodDnsServer, MockedReachabilityAdaptee, MockedGoodJSONEncoding> = {
         .init(server: goodServerMock, jsonEncoder: goodJsonEncodingMock, reachability: goodReachabilityMock)
     }()
     let rxSubscriber: MockedDNSContext.HttpKitRxSubscriber = .init()

--- a/catowser/CoreCatowserTests/WebViewVmDNSoverHTTPSTests.swift
+++ b/catowser/CoreCatowserTests/WebViewVmDNSoverHTTPSTests.swift
@@ -17,7 +17,7 @@ final class WebViewVmDNSoverHTTPSTests: XCTestCase {
     let goodJsonEncodingMock: MockedGoodJSONEncoding = .init()
     // swiftlint:disable:next force_unwrapping
     lazy var goodReachabilityMock: MockedReachabilityAdaptee = .init(server: goodServerMock)!
-    lazy var goodDnsClient: RestClient<MockedGoodDnsServer, MockedReachabilityAdaptee, MockedGoodJSONEncoding> = {
+    lazy var goodDnsClient: MockedRestInterface<MockedGoodDnsServer, MockedReachabilityAdaptee, MockedGoodJSONEncoding> = {
         .init(server: goodServerMock, jsonEncoder: goodJsonEncodingMock, reachability: goodReachabilityMock)
     }()
     let rxSubscriber: MockedDNSContext.HttpKitRxSubscriber = .init()

--- a/catowser/CoreCatowserTests/WebViewVmJSPluginsTests.swift
+++ b/catowser/CoreCatowserTests/WebViewVmJSPluginsTests.swift
@@ -18,7 +18,7 @@ final class WebViewVmJSPluginsTests: XCTestCase {
     let goodJsonEncodingMock: MockedGoodJSONEncoding = .init()
     // swiftlint:disable:next force_unwrapping
     lazy var goodReachabilityMock: MockedReachabilityAdaptee = .init(server: goodServerMock)!
-    lazy var goodDnsClient: RestClient<MockedGoodDnsServer, MockedReachabilityAdaptee> = {
+    lazy var goodDnsClient: RestClient<MockedGoodDnsServer, MockedReachabilityAdaptee, MockedGoodJSONEncoding> = {
         .init(server: goodServerMock, jsonEncoder: goodJsonEncodingMock, reachability: goodReachabilityMock)
     }()
     let rxSubscriber: MockedDNSContext.HttpKitRxSubscriber = .init()

--- a/catowser/CoreCatowserTests/WebViewVmJSPluginsTests.swift
+++ b/catowser/CoreCatowserTests/WebViewVmJSPluginsTests.swift
@@ -18,7 +18,9 @@ final class WebViewVmJSPluginsTests: XCTestCase {
     let goodJsonEncodingMock: MockedGoodJSONEncoding = .init()
     // swiftlint:disable:next force_unwrapping
     lazy var goodReachabilityMock: MockedReachabilityAdaptee = .init(server: goodServerMock)!
-    lazy var goodDnsClient: RestClient<MockedGoodDnsServer, MockedReachabilityAdaptee, MockedGoodJSONEncoding> = {
+    lazy var goodDnsClient: MockedRestInterface<MockedGoodDnsServer,
+                                                MockedReachabilityAdaptee,
+                                                MockedGoodJSONEncoding> = {
         .init(server: goodServerMock, jsonEncoder: goodJsonEncodingMock, reachability: goodReachabilityMock)
     }()
     let rxSubscriber: MockedDNSContext.HttpKitRxSubscriber = .init()

--- a/catowser/HttpKit/Extensions/CombineExtensions.swift
+++ b/catowser/HttpKit/Extensions/CombineExtensions.swift
@@ -12,10 +12,17 @@ import Combine
 #endif
 
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-extension Combine.Future {
-    public static func failure(_ error: Failure) -> Future<Output, Failure> {
+public extension Combine.Future {
+    static func failure(_ error: Failure) -> Future<Output, Failure> {
         let future: Future<Output, Failure> = .init { (promise) in
             promise(.failure(error))
+        }
+        return future
+    }
+    
+    static func success(_ value: Output) -> Future<Output, Failure> {
+        let future: Future<Output, Failure> = .init { (promise) in
+            promise(.success(value))
         }
         return future
     }

--- a/catowser/HttpKit/HttpClientImpl.swift
+++ b/catowser/HttpKit/HttpClientImpl.swift
@@ -1,5 +1,5 @@
 //
-//  HttpClient.swift
+//  HttpClientImpl.swift
 //  HttpKit
 //
 //  Created by Andrei Ermoshin on 10/11/19.
@@ -10,6 +10,7 @@ import Foundation
 #if canImport(Combine)
 import Combine
 #endif
+import CoreHttpKit
 
 fileprivate extension String {
     static let threadName = "Client"
@@ -18,7 +19,13 @@ fileprivate extension String {
 public typealias HttpTypedResult<T> = Result<T, HttpError>
 public typealias TypedResponseClosure<T> = (HttpTypedResult<T>) -> Void
 
-public class RestClient<Server, R: NetworkReachabilityAdapter> where R.Server == Server {
+public class RestClient<S: ServerDescription,
+                        R: NetworkReachabilityAdapter,
+                        E: JSONRequestEncodable>: RestInterface where R.Server == S {
+    public typealias Server = S
+    public typealias Reachability = R
+    public typealias Encoder = E
+    
     let server: Server
     
     private let connectivityManager: R?
@@ -43,10 +50,10 @@ public class RestClient<Server, R: NetworkReachabilityAdapter> where R.Server ==
         // TODO: need some interface for reachability but without RX (MutableProperty)
     }
     
-    public init(server: Server,
-                jsonEncoder: JSONRequestEncodable,
-                reachability: R,
-                httpTimeout: TimeInterval = 60) {
+    public required init(server: S,
+                         jsonEncoder: E,
+                         reachability: R,
+                         httpTimeout: TimeInterval = 60) {
         self.server = server
         self.httpTimeout = httpTimeout
         self.jsonEncoder = jsonEncoder

--- a/catowser/HttpKit/HttpClientImpl.swift
+++ b/catowser/HttpKit/HttpClientImpl.swift
@@ -11,6 +11,7 @@ import Foundation
 import Combine
 #endif
 import CoreHttpKit
+import AutoMockable
 
 fileprivate extension String {
     static let threadName = "Client"
@@ -19,9 +20,14 @@ fileprivate extension String {
 public typealias HttpTypedResult<T> = Result<T, HttpError>
 public typealias TypedResponseClosure<T> = (HttpTypedResult<T>) -> Void
 
+// swiftlint:disable comment_spacing
+//sourcery: typealias = "Server: ServerDescription"
+//sourcery: typealias = "Reachability: NetworkReachabilityAdapter"
+//sourcery: typealias = "Encoder: JSONRequestEncodable"
 public class RestClient<S: ServerDescription,
                         R: NetworkReachabilityAdapter,
-                        E: JSONRequestEncodable>: RestInterface where R.Server == S {
+                        E: JSONRequestEncodable>: RestInterface, AutoMockable where R.Server == S {
+    // swiftlint:enable comment_spacing
     public typealias Server = S
     public typealias Reachability = R
     public typealias Encoder = E

--- a/catowser/HttpKit/Interfaces/RequestInterfaces.swift
+++ b/catowser/HttpKit/Interfaces/RequestInterfaces.swift
@@ -8,8 +8,9 @@
 
 import Foundation
 import CoreHttpKit
+import AutoMockable
 
-public protocol URLRequestCreatable {
+public protocol URLRequestCreatable: AutoMockable {
     func convertToURLRequest() throws -> URLRequest
 }
 
@@ -21,7 +22,7 @@ extension URLRequest: URLRequestCreatable {
 
 /// Interface for some JSON encoder (e.g. Alamofire implementation) to hide it and
 /// not use it directly and be able to mock it for unit testing
-public protocol JSONRequestEncodable {
+public protocol JSONRequestEncodable: AutoMockable {
     func encodeRequest(_ urlRequest: URLRequestCreatable, with parameters: [String: Any]?) throws -> URLRequest
 }
 

--- a/catowser/HttpKit/NetworkReachabilityAdapter.swift
+++ b/catowser/HttpKit/NetworkReachabilityAdapter.swift
@@ -26,7 +26,10 @@ public enum NetworkReachabilityStatus {
     }
 }
 
+// swiftlint:disable comment_spacing
+//sourcery: associatedtype = "Server: ServerDescription"
 public protocol NetworkReachabilityAdapter: AnyObject, AutoMockable {
+    // swiftlint:enable comment_spacing
     associatedtype Server: ServerDescription
     typealias Listener = (NetworkReachabilityStatus) -> Void
     init?(server: Server)

--- a/catowser/HttpKit/NetworkReachabilityAdapter.swift
+++ b/catowser/HttpKit/NetworkReachabilityAdapter.swift
@@ -7,8 +7,8 @@
 //
 
 import CoreHttpKit
+import AutoMockable
 
-// gryphon ignore
 public enum NetworkReachabilityStatus {
     /// It is unknown whether the network is reachable.
     case unknown
@@ -26,8 +26,7 @@ public enum NetworkReachabilityStatus {
     }
 }
 
-// gryphon ignore
-public protocol NetworkReachabilityAdapter: AnyObject {
+public protocol NetworkReachabilityAdapter: AnyObject, AutoMockable {
     associatedtype Server: ServerDescription
     typealias Listener = (NetworkReachabilityStatus) -> Void
     init?(server: Server)

--- a/catowser/HttpKit/ResponseHandlingApiType.swift
+++ b/catowser/HttpKit/ResponseHandlingApiType.swift
@@ -10,6 +10,7 @@
 import Combine
 #endif
 import CoreHttpKit
+import AutoMockable
 
 // gryphon ignore
 public protocol RxAnyObserver {
@@ -31,7 +32,7 @@ public protocol RxAnyLifetime {
 /// This protocol is needed to not use ReactiveSwift dependency directly
 /// It should be implemented by RxObserverWrapper which is in different Framework
 // gryphon ignore
-public protocol RxInterface: Hashable, AnyObject {
+public protocol RxInterface: Hashable, AnyObject, AutoMockable {
     associatedtype Observer: RxAnyObserver
     associatedtype Server: ServerDescription
     

--- a/catowser/HttpKit/ResponseHandlingApiType.swift
+++ b/catowser/HttpKit/ResponseHandlingApiType.swift
@@ -12,7 +12,6 @@ import Combine
 import CoreHttpKit
 import AutoMockable
 
-// gryphon ignore
 public protocol RxAnyObserver {
     associatedtype Response: ResponseType
     func newSend(value: Response)
@@ -31,8 +30,7 @@ public protocol RxAnyLifetime {
 
 /// This protocol is needed to not use ReactiveSwift dependency directly
 /// It should be implemented by RxObserverWrapper which is in different Framework
-// gryphon ignore
-public protocol RxInterface: Hashable, AnyObject, AutoMockable {
+public protocol RxInterface: Hashable, AnyObject {
     associatedtype Observer: RxAnyObserver
     associatedtype Server: ServerDescription
     

--- a/catowser/HttpKit/ResponseType.swift
+++ b/catowser/HttpKit/ResponseType.swift
@@ -7,10 +7,9 @@
 //
 
 import Foundation
-import AutoMockable
 
-public protocol ResponseType: Decodable, AutoMockable {
-     static var successCodes: [Int] { get }
+public protocol ResponseType: Decodable {
+    static var successCodes: [Int] { get }
 }
 
 extension ResponseType {

--- a/catowser/HttpKit/ResponseType.swift
+++ b/catowser/HttpKit/ResponseType.swift
@@ -7,8 +7,9 @@
 //
 
 import Foundation
+import AutoMockable
 
-public protocol ResponseType: Decodable {
+public protocol ResponseType: Decodable, AutoMockable {
      static var successCodes: [Int] { get }
 }
 

--- a/catowser/HttpKit/RestClient+AsyncAwait.swift
+++ b/catowser/HttpKit/RestClient+AsyncAwait.swift
@@ -1,5 +1,5 @@
 //
-//  HttpClient+AsyncAwait.swift
+//  RestClient+AsyncAwait.swift
 //  HttpKit
 //
 //  Created by Andrei Ermoshin on 6/10/21.

--- a/catowser/HttpKit/RestClient+Combine.swift
+++ b/catowser/HttpKit/RestClient+Combine.swift
@@ -1,5 +1,5 @@
 //
-//  HttpClient+Combine.swift
+//  RestClient+Combine.swift
 //  HttpKit
 //
 //  Created by Andrei Ermoshin on 4/28/20.

--- a/catowser/HttpKit/RestClient+Kotlin.swift
+++ b/catowser/HttpKit/RestClient+Kotlin.swift
@@ -1,5 +1,5 @@
 //
-//  HttpClient+Kotlin.swift
+//  RestClient+Kotlin.swift
 //  HttpKit
 //
 //  Created by Andrei Ermoshin on 4/16/22.

--- a/catowser/HttpKit/RestClient+URLSessionDelegate.swift
+++ b/catowser/HttpKit/RestClient+URLSessionDelegate.swift
@@ -1,5 +1,5 @@
 //
-//  HttpClient+URLSessionDelegate.swift
+//  RestClient+URLSessionDelegate.swift
 //  HttpKit
 //
 //  Created by Andrei Ermoshin on 6/14/21.

--- a/catowser/HttpKit/RestClient+URLSessionTaskDelegate.swift
+++ b/catowser/HttpKit/RestClient+URLSessionTaskDelegate.swift
@@ -1,5 +1,5 @@
 //
-//  HttpClient+URLSessionTaskDelegate.swift
+//  RestClient+URLSessionTaskDelegate.swift
 //  HttpKit
 //
 //  Created by Andrei Ermoshin on 6/11/21.

--- a/catowser/HttpKit/RestClient.swift
+++ b/catowser/HttpKit/RestClient.swift
@@ -1,5 +1,5 @@
 //
-//  HttpClientImpl.swift
+//  RestClient.swift
 //  HttpKit
 //
 //  Created by Andrei Ermoshin on 10/11/19.
@@ -11,7 +11,6 @@ import Foundation
 import Combine
 #endif
 import CoreHttpKit
-import AutoMockable
 
 fileprivate extension String {
     static let threadName = "Client"
@@ -20,14 +19,9 @@ fileprivate extension String {
 public typealias HttpTypedResult<T> = Result<T, HttpError>
 public typealias TypedResponseClosure<T> = (HttpTypedResult<T>) -> Void
 
-// swiftlint:disable comment_spacing
-//sourcery: typealias = "Server: ServerDescription"
-//sourcery: typealias = "Reachability: NetworkReachabilityAdapter"
-//sourcery: typealias = "Encoder: JSONRequestEncodable"
 public class RestClient<S: ServerDescription,
                         R: NetworkReachabilityAdapter,
-                        E: JSONRequestEncodable>: RestInterface, AutoMockable where R.Server == S {
-    // swiftlint:enable comment_spacing
+                        E: JSONRequestEncodable>: RestInterface where R.Server == S {
     public typealias Server = S
     public typealias Reachability = R
     public typealias Encoder = E

--- a/catowser/HttpKit/RestClient.swift
+++ b/catowser/HttpKit/RestClient.swift
@@ -26,7 +26,9 @@ public class RestClient<S: ServerDescription,
     public typealias Reachability = R
     public typealias Encoder = E
     
-    let server: Server
+    public let server: Server
+    
+    public let jsonEncoder: Encoder
     
     private let connectivityManager: R?
     
@@ -40,8 +42,6 @@ public class RestClient<S: ServerDescription,
     let urlSession: URLSession
     
     let httpTimeout: TimeInterval
-    
-    let jsonEncoder: JSONRequestEncodable
     
     private lazy var hostListener: NetworkReachabilityAdapter.Listener = { [weak self] status in
         guard let self = self else {

--- a/catowser/HttpKit/RestClientError.swift
+++ b/catowser/HttpKit/RestClientError.swift
@@ -1,5 +1,5 @@
 //
-//  HttpKitErrors.swift
+//  RestClientError.swift
 //  HttpKit
 //
 //  Created by Andrei Ermoshin on 10/12/19.

--- a/catowser/HttpKit/RestInterface.swift
+++ b/catowser/HttpKit/RestInterface.swift
@@ -26,4 +26,7 @@ public protocol RestInterface: AnyObject, AutoMockable {
     associatedtype Encoder: JSONRequestEncodable
     
     init(server: Server, jsonEncoder: Encoder, reachability: Reachability, httpTimeout: TimeInterval)
+    
+    var server: Server { get }
+    var jsonEncoder: Encoder { get }
 }

--- a/catowser/HttpKit/RestInterface.swift
+++ b/catowser/HttpKit/RestInterface.swift
@@ -1,0 +1,24 @@
+//
+//  RestInterface.swift
+//  HttpKit
+//
+//  Created by Andrei Ermoshin on 10/27/22.
+//  Copyright © 2022 andreiermoshin. All rights reserved.
+//
+
+import Foundation
+import CoreHttpKit
+import AutoMockable
+
+// swiftlint:disable comment_spacing
+//sourcery: associatedtype = "Server: ServerDescription"
+//sourcery: associatedtype = "Reachability: NetworkReachabilityAdapter"
+//sourcery: associatedtype = "Encoder: JSONRequestEncodable"
+public protocol RestInterface: AnyObject, AutoMockable {
+    // swiftlint:enable comment_spacing
+    associatedtype Server: ServerDescription
+    associatedtype Reachability: NetworkReachabilityAdapter where Reachability.Server == Server
+    associatedtype Encoder: JSONRequestEncodable
+    
+    init(server: Server, jsonEncoder: Encoder, reachability: Reachability, httpTimeout: TimeInterval)
+}

--- a/catowser/HttpKit/RestInterface.swift
+++ b/catowser/HttpKit/RestInterface.swift
@@ -10,10 +10,15 @@ import Foundation
 import CoreHttpKit
 import AutoMockable
 
+extension ServerDescription: AutoMockable {}
+
 // swiftlint:disable comment_spacing
 //sourcery: associatedtype = "Server: ServerDescription"
 //sourcery: associatedtype = "Reachability: NetworkReachabilityAdapter"
 //sourcery: associatedtype = "Encoder: JSONRequestEncodable"
+//sourcery: typealias = "Server = Server"
+//sourcery: typealias = "Reachability = Reachability"
+//sourcery: typealias = "Encoder = Encoder"
 public protocol RestInterface: AnyObject, AutoMockable {
     // swiftlint:enable comment_spacing
     associatedtype Server: ServerDescription

--- a/catowser/HttpKit/RestInterface.swift
+++ b/catowser/HttpKit/RestInterface.swift
@@ -10,15 +10,15 @@ import Foundation
 import CoreHttpKit
 import AutoMockable
 
-extension ServerDescription: AutoMockable {}
+// Can't mock `ServerDescription` because need to call base init somehow
 
 // swiftlint:disable comment_spacing
-//sourcery: associatedtype = "Server: ServerDescription"
-//sourcery: associatedtype = "Reachability: NetworkReachabilityAdapter"
-//sourcery: associatedtype = "Encoder: JSONRequestEncodable"
-//sourcery: typealias = "Server = Server"
-//sourcery: typealias = "Reachability = Reachability"
-//sourcery: typealias = "Encoder = Encoder"
+//sourcery: associatedtype = "S: ServerDescription"
+//sourcery: associatedtype = "RA: NetworkReachabilityAdapter where RA.Server == S"
+//sourcery: associatedtype = "E: JSONRequestEncodable"
+//sourcery: typealias = "Server = S"
+//sourcery: typealias = "Reachability = RA"
+//sourcery: typealias = "Encoder = E"
 public protocol RestInterface: AnyObject, AutoMockable {
     // swiftlint:enable comment_spacing
     associatedtype Server: ServerDescription

--- a/catowser/HttpKitTests/HttpClientTests.swift
+++ b/catowser/HttpKitTests/HttpClientTests.swift
@@ -19,9 +19,9 @@ class HttpClientTests: XCTestCase {
     let goodJsonEncodingMock: MockedGoodJSONEncoding = .init()
     // swiftlint:disable:next force_unwrapping
     lazy var goodReachabilityMock: MockedReachabilityAdaptee = .init(server: goodServerMock)!
-    lazy var goodHttpClient: RestClient<MockedGoodServer, MockedReachabilityAdaptee> = .init(server: goodServerMock,
-                                                                                             jsonEncoder: goodJsonEncodingMock,
-                                                                                             reachability: goodReachabilityMock)
+    lazy var goodHttpClient = RestClient(server: goodServerMock,
+                                         jsonEncoder: goodJsonEncodingMock,
+                                         reachability: goodReachabilityMock)
 
     func testUnauthorizedRequest() throws {
         let expectationUrlFail = XCTestExpectation(description: "Failed to construct URL")

--- a/catowser/Mockfile
+++ b/catowser/Mockfile
@@ -1,0 +1,13 @@
+# Mockfile is a SwiftyMocky YAML configuration file
+sourceryCommand: null
+CoreCatowserTarget: # Distinctive name of your mock configuration target
+  sources:
+    include:        # All swift files here would be scanned for AutoMockable types
+        - ./CoreCatowser/SearchViewModel/Autocomplete
+    exclude: []     # You can exclude files as well
+  output:           # Generated mock file location and name
+    ./CoreCatowserTests/GeneratedMocks/Mock.generated.swift
+  targets:          # Specify XCodeproj targets for your mock. Used for linting
+    - CoreCatowserTests
+  testable: [CoreCatowser] 
+  import: [HttpKit, ReactiveSwift, Combine, CoreHttpKit, ReactiveHttpKit, BrowserNetworking]

--- a/catowser/Mockfile
+++ b/catowser/Mockfile
@@ -4,12 +4,14 @@ CoreCatowserTarget: # Distinctive name of your mock configuration target
   sources:
     include:        # All swift files here would be scanned for AutoMockable types
         - ./CoreCatowser/SearchViewModel/Autocomplete
+        - ./CoreCatowser/SearchViewModel
         - ./HttpKit
         - ./HttpKit/Interfaces
+        - ./CoreBrowser/History
     exclude: []     # You can exclude files as well
   output:           # Generated mock file location and name
     ./CoreCatowserTests/GeneratedMocks/Mock.generated.swift
   targets:          # Specify XCodeproj targets for your mock. Used for linting
     - CoreCatowserTests
   testable: [CoreCatowser] 
-  import: [HttpKit, ReactiveSwift, Combine, CoreHttpKit, ReactiveHttpKit, BrowserNetworking]
+  import: [HttpKit, ReactiveSwift, Combine, CoreHttpKit, ReactiveHttpKit, BrowserNetworking, FeaturesFlagsKit, CoreBrowser]

--- a/catowser/Mockfile
+++ b/catowser/Mockfile
@@ -4,6 +4,8 @@ CoreCatowserTarget: # Distinctive name of your mock configuration target
   sources:
     include:        # All swift files here would be scanned for AutoMockable types
         - ./CoreCatowser/SearchViewModel/Autocomplete
+        - ./HttpKit
+        - ./HttpKit/Interfaces
     exclude: []     # You can exclude files as well
   output:           # Generated mock file location and name
     ./CoreCatowserTests/GeneratedMocks/Mock.generated.swift

--- a/catowser/catowser.xcodeproj/project.pbxproj
+++ b/catowser/catowser.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		8A0DF8FE224C0146000CADA6 /* DummyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0DF8FD224C0146000CADA6 /* DummyDecodable.swift */; };
 		8A0DF900224C019C000CADA6 /* InstagramVideoArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0DF8FF224C019C000CADA6 /* InstagramVideoArray.swift */; };
 		8A0E0EAB224A94E600D86CD7 /* InstagramVideoNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0E0EAA224A94E600D86CD7 /* InstagramVideoNode.swift */; };
+		8A0E4D5729133C02008F7964 /* Mock.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0E4D5629133C02008F7964 /* Mock.generated.swift */; };
 		8A1115EB24837DA400E63114 /* TabAddPositionsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1115EA24837DA400E63114 /* TabAddPositionsModel.swift */; };
 		8A1115EC24837DA400E63114 /* TabAddPositionsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1115EA24837DA400E63114 /* TabAddPositionsModel.swift */; };
 		8A1A1CE727B1966E0052A2A3 /* AlamofireHTTPRxAdaptee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB0D4102755075700493EC3 /* AlamofireHTTPRxAdaptee.swift */; };
@@ -964,6 +965,7 @@
 		8A0DF8FD224C0146000CADA6 /* DummyDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyDecodable.swift; sourceTree = "<group>"; };
 		8A0DF8FF224C019C000CADA6 /* InstagramVideoArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstagramVideoArray.swift; sourceTree = "<group>"; };
 		8A0E0EAA224A94E600D86CD7 /* InstagramVideoNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstagramVideoNode.swift; sourceTree = "<group>"; };
+		8A0E4D5629133C02008F7964 /* Mock.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mock.generated.swift; sourceTree = "<group>"; };
 		8A1115EA24837DA400E63114 /* TabAddPositionsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabAddPositionsModel.swift; sourceTree = "<group>"; };
 		8A16102828947C2F00D45228 /* DNSResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DNSResolver.swift; sourceTree = "<group>"; };
 		8A16102E28947D2100D45228 /* DNSResolvingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DNSResolvingStrategy.swift; sourceTree = "<group>"; };
@@ -1840,6 +1842,7 @@
 		8A5E6C75290B0C430034A78B /* GeneratedMocks */ = {
 			isa = PBXGroup;
 			children = (
+				8A0E4D5629133C02008F7964 /* Mock.generated.swift */,
 			);
 			path = GeneratedMocks;
 			sourceTree = "<group>";
@@ -3516,6 +3519,7 @@
 				8ACE7BEA28ED4F10001CBAED /* DNSResolvingStrategyMocks.swift in Sources */,
 				8AC6D5F928F008EC008379C0 /* NavigationActionableMocks.swift in Sources */,
 				8AEA9456290F01E800CCBB46 /* MockedRestInterface.swift in Sources */,
+				8A0E4D5729133C02008F7964 /* Mock.generated.swift in Sources */,
 				8A06D6F728EC2CF8001CB63D /* ServerDescriptionMocks.swift in Sources */,
 				8A06D6F528EC2C5D001CB63D /* ResponseTypeMocks.swift in Sources */,
 				8ACE7BEC28ED4FC9001CBAED /* WebViewContextMocks.swift in Sources */,

--- a/catowser/catowser.xcodeproj/project.pbxproj
+++ b/catowser/catowser.xcodeproj/project.pbxproj
@@ -474,6 +474,7 @@
 		8AE6D16D2350FF35006316AD /* HttpKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AE6D16B2350FF35006316AD /* HttpKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8AE8D045280D388800FADE3A /* ResponseType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE8D044280D388800FADE3A /* ResponseType.swift */; };
 		8AE8D048280D3CB500FADE3A /* HttpKotlinTypes+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE8D047280D3CB500FADE3A /* HttpKotlinTypes+Extensions.swift */; };
+		8AEA9456290F01E800CCBB46 /* MockedRestInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEA9455290F01E800CCBB46 /* MockedRestInterface.swift */; };
 		8AEDCE6828F02E41008516FD /* WebViewVmDNSoverHTTPSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEDCE6728F02E41008516FD /* WebViewVmDNSoverHTTPSTests.swift */; };
 		8AF4336C248E129F0047452B /* HTMLContentMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF4336B248E129F0047452B /* HTMLContentMessage.swift */; };
 		8AF4336F248EA3BE0047452B /* CSSBackgroundImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF4336E248EA3BE0047452B /* CSSBackgroundImage.swift */; };
@@ -1139,6 +1140,7 @@
 		8AE6D16C2350FF35006316AD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8AE8D044280D388800FADE3A /* ResponseType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseType.swift; sourceTree = "<group>"; };
 		8AE8D047280D3CB500FADE3A /* HttpKotlinTypes+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HttpKotlinTypes+Extensions.swift"; sourceTree = "<group>"; };
+		8AEA9455290F01E800CCBB46 /* MockedRestInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockedRestInterface.swift; sourceTree = "<group>"; };
 		8AEDCE6728F02E41008516FD /* WebViewVmDNSoverHTTPSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewVmDNSoverHTTPSTests.swift; sourceTree = "<group>"; };
 		8AF0B95728B9FA2C001D202C /* WebViewModelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewModelState.swift; sourceTree = "<group>"; };
 		8AF0B95A28B9FA8A001D202C /* WebViewModelState+Actionable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebViewModelState+Actionable.swift"; sourceTree = "<group>"; };
@@ -1727,6 +1729,7 @@
 				8AD8B47D28F2CAB100E0857D /* JSPluginsProgramMocks.swift */,
 				8ACE7BED28ED6E0F001CBAED /* WebViewMocks.swift */,
 				8AC6D5F828F008EC008379C0 /* NavigationActionableMocks.swift */,
+				8AEA9455290F01E800CCBB46 /* MockedRestInterface.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -3512,6 +3515,7 @@
 				8A06D6FA28EC2FC8001CB63D /* ReachabilityAdapteeMocks.swift in Sources */,
 				8ACE7BEA28ED4F10001CBAED /* DNSResolvingStrategyMocks.swift in Sources */,
 				8AC6D5F928F008EC008379C0 /* NavigationActionableMocks.swift in Sources */,
+				8AEA9456290F01E800CCBB46 /* MockedRestInterface.swift in Sources */,
 				8A06D6F728EC2CF8001CB63D /* ServerDescriptionMocks.swift in Sources */,
 				8A06D6F528EC2C5D001CB63D /* ResponseTypeMocks.swift in Sources */,
 				8ACE7BEC28ED4FC9001CBAED /* WebViewContextMocks.swift in Sources */,

--- a/catowser/catowser.xcodeproj/project.pbxproj
+++ b/catowser/catowser.xcodeproj/project.pbxproj
@@ -126,6 +126,8 @@
 		8A0DF900224C019C000CADA6 /* InstagramVideoArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0DF8FF224C019C000CADA6 /* InstagramVideoArray.swift */; };
 		8A0E0EAB224A94E600D86CD7 /* InstagramVideoNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0E0EAA224A94E600D86CD7 /* InstagramVideoNode.swift */; };
 		8A0E4D5729133C02008F7964 /* Mock.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0E4D5629133C02008F7964 /* Mock.generated.swift */; };
+		8A0E4D5A29133E77008F7964 /* SwiftyMocky in Frameworks */ = {isa = PBXBuildFile; productRef = 8A0E4D5929133E77008F7964 /* SwiftyMocky */; };
+		8A0E4D5B29133F65008F7964 /* SearchSuggestionsVMCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB9BE0928FEB17E002063C2 /* SearchSuggestionsVMCombineTests.swift */; };
 		8A1115EB24837DA400E63114 /* TabAddPositionsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1115EA24837DA400E63114 /* TabAddPositionsModel.swift */; };
 		8A1115EC24837DA400E63114 /* TabAddPositionsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1115EA24837DA400E63114 /* TabAddPositionsModel.swift */; };
 		8A1A1CE727B1966E0052A2A3 /* AlamofireHTTPRxAdaptee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB0D4102755075700493EC3 /* AlamofireHTTPRxAdaptee.swift */; };
@@ -1259,6 +1261,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8A7B1BA028EB131F004FC135 /* CoreCatowser.framework in Frameworks */,
+				8A0E4D5A29133E77008F7964 /* SwiftyMocky in Frameworks */,
 				8AD4F54728F4941A009C4BDC /* ReactiveSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2535,6 +2538,7 @@
 			name = CoreCatowserTests;
 			packageProductDependencies = (
 				8AD4F54628F4941A009C4BDC /* ReactiveSwift */,
+				8A0E4D5929133E77008F7964 /* SwiftyMocky */,
 			);
 			productName = CoreCatowserTests;
 			productReference = 8A7B1B9F28EB131F004FC135 /* CoreCatowserTests.xctest */;
@@ -2830,6 +2834,7 @@
 				8AA6608828F43F790058490F /* XCRemoteSwiftPackageReference "SWXMLHash" */,
 				8A03F44028F4769B00E4A296 /* XCRemoteSwiftPackageReference "ReactiveSwift" */,
 				8A03F45828F47ACB00E4A296 /* XCRemoteSwiftPackageReference "SwiftSoup" */,
+				8A0E4D5829133E77008F7964 /* XCRemoteSwiftPackageReference "SwiftyMocky" */,
 			);
 			productRefGroup = 8435A4981EED5E700020102F /* Products */;
 			projectDirPath = "";
@@ -3514,6 +3519,7 @@
 				8AEDCE6828F02E41008516FD /* WebViewVmDNSoverHTTPSTests.swift in Sources */,
 				8A815D3B28F15EC5007A6926 /* WebViewVmJSPluginsTests.swift in Sources */,
 				8A06D6FC28EC30A7001CB63D /* JSONEncodableMocks.swift in Sources */,
+				8A0E4D5B29133F65008F7964 /* SearchSuggestionsVMCombineTests.swift in Sources */,
 				8A7B1BA728EB131F004FC135 /* WebViewVMCombineTests.swift in Sources */,
 				8A06D6FA28EC2FC8001CB63D /* ReachabilityAdapteeMocks.swift in Sources */,
 				8ACE7BEA28ED4F10001CBAED /* DNSResolvingStrategyMocks.swift in Sources */,
@@ -5367,6 +5373,14 @@
 				version = 2.4.3;
 			};
 		};
+		8A0E4D5829133E77008F7964 /* XCRemoteSwiftPackageReference "SwiftyMocky" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/MakeAWishFoundation/SwiftyMocky";
+			requirement = {
+				kind = exactVersion;
+				version = 4.2.0;
+			};
+		};
 		8AA6608828F43F790058490F /* XCRemoteSwiftPackageReference "SWXMLHash" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/drmohundro/SWXMLHash";
@@ -5398,6 +5412,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 8A03F45828F47ACB00E4A296 /* XCRemoteSwiftPackageReference "SwiftSoup" */;
 			productName = SwiftSoup;
+		};
+		8A0E4D5929133E77008F7964 /* SwiftyMocky */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8A0E4D5829133E77008F7964 /* XCRemoteSwiftPackageReference "SwiftyMocky" */;
+			productName = SwiftyMocky;
 		};
 		8A5E6CB0290B21B50034A78B /* Alamofire */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/catowser/catowser.xcodeproj/project.pbxproj
+++ b/catowser/catowser.xcodeproj/project.pbxproj
@@ -186,7 +186,6 @@
 		8A5E6C93290B107B0034A78B /* AutoMockable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A5E6C7D290B0E6C0034A78B /* AutoMockable.framework */; };
 		8A5E6CAF290B1D4F0034A78B /* RestInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5E6CAE290B1D4F0034A78B /* RestInterface.swift */; };
 		8A5E6CB1290B21B50034A78B /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 8A5E6CB0290B21B50034A78B /* Alamofire */; };
-		8A5E6CB3290B228B0034A78B /* Mock.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5E6CB2290B228B0034A78B /* Mock.generated.swift */; };
 		8A5F71F62826C148008E5638 /* CoreHttpKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A5F71F52826C148008E5638 /* CoreHttpKit.xcframework */; };
 		8A5F71F72826C148008E5638 /* CoreHttpKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8A5F71F52826C148008E5638 /* CoreHttpKit.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8A5F71F82826C183008E5638 /* CoreHttpKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A5F71F52826C148008E5638 /* CoreHttpKit.xcframework */; };
@@ -475,6 +474,7 @@
 		8AE6D16D2350FF35006316AD /* HttpKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AE6D16B2350FF35006316AD /* HttpKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8AE8D045280D388800FADE3A /* ResponseType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE8D044280D388800FADE3A /* ResponseType.swift */; };
 		8AE8D048280D3CB500FADE3A /* HttpKotlinTypes+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE8D047280D3CB500FADE3A /* HttpKotlinTypes+Extensions.swift */; };
+		8AEA9454290E6DA100CCBB46 /* Mock.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEA9453290E6DA000CCBB46 /* Mock.generated.swift */; };
 		8AEDCE6828F02E41008516FD /* WebViewVmDNSoverHTTPSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEDCE6728F02E41008516FD /* WebViewVmDNSoverHTTPSTests.swift */; };
 		8AF4336C248E129F0047452B /* HTMLContentMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF4336B248E129F0047452B /* HTMLContentMessage.swift */; };
 		8AF4336F248EA3BE0047452B /* CSSBackgroundImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF4336E248EA3BE0047452B /* CSSBackgroundImage.swift */; };
@@ -1005,7 +1005,6 @@
 		8A5E6C7D290B0E6C0034A78B /* AutoMockable.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AutoMockable.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A5E6C7F290B0E6C0034A78B /* AutoMockable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AutoMockable.h; sourceTree = "<group>"; };
 		8A5E6CAE290B1D4F0034A78B /* RestInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestInterface.swift; sourceTree = "<group>"; };
-		8A5E6CB2290B228B0034A78B /* Mock.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mock.generated.swift; sourceTree = "<group>"; };
 		8A5F71F52826C148008E5638 /* CoreHttpKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CoreHttpKit.xcframework; path = ../CoreHttpKit/build/XCFrameworks/release/CoreHttpKit.xcframework; sourceTree = "<group>"; };
 		8A5FD6A826AF34570019384A /* AppErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrors.swift; sourceTree = "<group>"; };
 		8A624074288D98DA006DDC66 /* SearchSuggestionsViewModelImpl+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchSuggestionsViewModelImpl+AsyncAwait.swift"; sourceTree = "<group>"; };
@@ -1141,6 +1140,7 @@
 		8AE6D16C2350FF35006316AD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8AE8D044280D388800FADE3A /* ResponseType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseType.swift; sourceTree = "<group>"; };
 		8AE8D047280D3CB500FADE3A /* HttpKotlinTypes+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HttpKotlinTypes+Extensions.swift"; sourceTree = "<group>"; };
+		8AEA9453290E6DA000CCBB46 /* Mock.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mock.generated.swift; sourceTree = "<group>"; };
 		8AEDCE6728F02E41008516FD /* WebViewVmDNSoverHTTPSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewVmDNSoverHTTPSTests.swift; sourceTree = "<group>"; };
 		8AF0B95728B9FA2C001D202C /* WebViewModelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewModelState.swift; sourceTree = "<group>"; };
 		8AF0B95A28B9FA8A001D202C /* WebViewModelState+Actionable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebViewModelState+Actionable.swift"; sourceTree = "<group>"; };
@@ -1839,7 +1839,7 @@
 		8A5E6C75290B0C430034A78B /* GeneratedMocks */ = {
 			isa = PBXGroup;
 			children = (
-				8A5E6CB2290B228B0034A78B /* Mock.generated.swift */,
+				8AEA9453290E6DA000CCBB46 /* Mock.generated.swift */,
 			);
 			path = GeneratedMocks;
 			sourceTree = "<group>";
@@ -3515,7 +3515,7 @@
 				8A06D6FA28EC2FC8001CB63D /* ReachabilityAdapteeMocks.swift in Sources */,
 				8ACE7BEA28ED4F10001CBAED /* DNSResolvingStrategyMocks.swift in Sources */,
 				8AC6D5F928F008EC008379C0 /* NavigationActionableMocks.swift in Sources */,
-				8A5E6CB3290B228B0034A78B /* Mock.generated.swift in Sources */,
+				8AEA9454290E6DA100CCBB46 /* Mock.generated.swift in Sources */,
 				8A06D6F728EC2CF8001CB63D /* ServerDescriptionMocks.swift in Sources */,
 				8A06D6F528EC2C5D001CB63D /* ResponseTypeMocks.swift in Sources */,
 				8ACE7BEC28ED4FC9001CBAED /* WebViewContextMocks.swift in Sources */,

--- a/catowser/catowser.xcodeproj/project.pbxproj
+++ b/catowser/catowser.xcodeproj/project.pbxproj
@@ -461,7 +461,7 @@
 		8AD4F54128F4936B009C4BDC /* ReactiveHttpKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8AB70E9127B7AE7A003FB59B /* ReactiveHttpKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8AD4F54528F493B8009C4BDC /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 8AD4F54428F493B8009C4BDC /* Alamofire */; };
 		8AD4F54728F4941A009C4BDC /* ReactiveSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 8AD4F54628F4941A009C4BDC /* ReactiveSwift */; };
-		8AD5E03E29153F6200901DA2 /* SearchSuggestionsVMCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD5E03D29153F6200901DA2 /* SearchSuggestionsVMCombineTests.swift */; };
+		8AD5E03E29153F6200901DA2 /* SearchSuggestionsVMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD5E03D29153F6200901DA2 /* SearchSuggestionsVMTests.swift */; };
 		8AD5E0402915485200901DA2 /* SearchViewContextImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD5E03F2915485200901DA2 /* SearchViewContextImpl.swift */; };
 		8AD5E0412915485200901DA2 /* SearchViewContextImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD5E03F2915485200901DA2 /* SearchViewContextImpl.swift */; };
 		8AD62B7928F55079003F3940 /* AutoMockable.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD62B7828F55078003F3940 /* AutoMockable.generated.swift */; };
@@ -1129,7 +1129,7 @@
 		8ACE7BED28ED6E0F001CBAED /* WebViewMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewMocks.swift; sourceTree = "<group>"; };
 		8AD18E0F2447580A00224702 /* ResourceReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceReader.swift; sourceTree = "<group>"; };
 		8AD2CEE62444DD7C00FFCBC7 /* duckduckgo.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = duckduckgo.xml; sourceTree = "<group>"; };
-		8AD5E03D29153F6200901DA2 /* SearchSuggestionsVMCombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSuggestionsVMCombineTests.swift; sourceTree = "<group>"; };
+		8AD5E03D29153F6200901DA2 /* SearchSuggestionsVMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSuggestionsVMTests.swift; sourceTree = "<group>"; };
 		8AD5E03F2915485200901DA2 /* SearchViewContextImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewContextImpl.swift; sourceTree = "<group>"; };
 		8AD62B6F28F547E6003F3940 /* Sourcery */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Sourcery; sourceTree = "<group>"; };
 		8AD62B7828F55078003F3940 /* AutoMockable.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoMockable.generated.swift; sourceTree = "<group>"; };
@@ -1916,7 +1916,7 @@
 				8AEDCE6728F02E41008516FD /* WebViewVmDNSoverHTTPSTests.swift */,
 				8A815D3A28F15EC5007A6926 /* WebViewVmJSPluginsTests.swift */,
 				8AB9BE0928FEB17E002063C2 /* WebSearchAutocompleteTests.swift */,
-				8AD5E03D29153F6200901DA2 /* SearchSuggestionsVMCombineTests.swift */,
+				8AD5E03D29153F6200901DA2 /* SearchSuggestionsVMTests.swift */,
 				8A5E6C75290B0C430034A78B /* GeneratedMocks */,
 				8A06D6F828EC2FB6001CB63D /* Mocks */,
 			);
@@ -3527,7 +3527,7 @@
 				8AEDCE6828F02E41008516FD /* WebViewVmDNSoverHTTPSTests.swift in Sources */,
 				8A815D3B28F15EC5007A6926 /* WebViewVmJSPluginsTests.swift in Sources */,
 				8A06D6FC28EC30A7001CB63D /* JSONEncodableMocks.swift in Sources */,
-				8AD5E03E29153F6200901DA2 /* SearchSuggestionsVMCombineTests.swift in Sources */,
+				8AD5E03E29153F6200901DA2 /* SearchSuggestionsVMTests.swift in Sources */,
 				8A0E4D5B29133F65008F7964 /* WebSearchAutocompleteTests.swift in Sources */,
 				8A7B1BA728EB131F004FC135 /* WebViewVMCombineTests.swift in Sources */,
 				8A06D6FA28EC2FC8001CB63D /* ReachabilityAdapteeMocks.swift in Sources */,

--- a/catowser/catowser.xcodeproj/project.pbxproj
+++ b/catowser/catowser.xcodeproj/project.pbxproj
@@ -127,7 +127,7 @@
 		8A0E0EAB224A94E600D86CD7 /* InstagramVideoNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0E0EAA224A94E600D86CD7 /* InstagramVideoNode.swift */; };
 		8A0E4D5729133C02008F7964 /* Mock.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0E4D5629133C02008F7964 /* Mock.generated.swift */; };
 		8A0E4D5A29133E77008F7964 /* SwiftyMocky in Frameworks */ = {isa = PBXBuildFile; productRef = 8A0E4D5929133E77008F7964 /* SwiftyMocky */; };
-		8A0E4D5B29133F65008F7964 /* SearchSuggestionsVMCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB9BE0928FEB17E002063C2 /* SearchSuggestionsVMCombineTests.swift */; };
+		8A0E4D5B29133F65008F7964 /* WebSearchAutocompleteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB9BE0928FEB17E002063C2 /* WebSearchAutocompleteTests.swift */; };
 		8A1115EB24837DA400E63114 /* TabAddPositionsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1115EA24837DA400E63114 /* TabAddPositionsModel.swift */; };
 		8A1115EC24837DA400E63114 /* TabAddPositionsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1115EA24837DA400E63114 /* TabAddPositionsModel.swift */; };
 		8A1A1CE727B1966E0052A2A3 /* AlamofireHTTPRxAdaptee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB0D4102755075700493EC3 /* AlamofireHTTPRxAdaptee.swift */; };
@@ -1100,7 +1100,7 @@
 		8AB70EA327B7B214003FB59B /* RxObserverWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RxObserverWrapper.swift; sourceTree = "<group>"; };
 		8AB70EA527B7B518003FB59B /* HTTPAdapter+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HTTPAdapter+Rx.swift"; sourceTree = "<group>"; };
 		8AB8018927C3E597002D6628 /* BaseMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseMenuView.swift; sourceTree = "<group>"; };
-		8AB9BE0928FEB17E002063C2 /* SearchSuggestionsVMCombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSuggestionsVMCombineTests.swift; sourceTree = "<group>"; };
+		8AB9BE0928FEB17E002063C2 /* WebSearchAutocompleteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSearchAutocompleteTests.swift; sourceTree = "<group>"; };
 		8AB9BE2128FF0D5C002063C2 /* Tab+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tab+Extension.swift"; sourceTree = "<group>"; };
 		8AB9BE2428FF0FB1002063C2 /* TabsListManager+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabsListManager+Extension.swift"; sourceTree = "<group>"; };
 		8ABA3CCE2522601800E304E2 /* TabsDBClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsDBClient.swift; sourceTree = "<group>"; };
@@ -1909,7 +1909,7 @@
 				8A7B1BA628EB131F004FC135 /* WebViewVMCombineTests.swift */,
 				8AEDCE6728F02E41008516FD /* WebViewVmDNSoverHTTPSTests.swift */,
 				8A815D3A28F15EC5007A6926 /* WebViewVmJSPluginsTests.swift */,
-				8AB9BE0928FEB17E002063C2 /* SearchSuggestionsVMCombineTests.swift */,
+				8AB9BE0928FEB17E002063C2 /* WebSearchAutocompleteTests.swift */,
 				8A5E6C75290B0C430034A78B /* GeneratedMocks */,
 				8A06D6F828EC2FB6001CB63D /* Mocks */,
 			);
@@ -3130,7 +3130,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(PROJECT_DIR)/CoreCatowserTests/Mock.generated.swift",
+				"$(PROJECT_DIR)/CoreCatowserTests/GeneratedMocks/Mock.generated.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -3519,7 +3519,7 @@
 				8AEDCE6828F02E41008516FD /* WebViewVmDNSoverHTTPSTests.swift in Sources */,
 				8A815D3B28F15EC5007A6926 /* WebViewVmJSPluginsTests.swift in Sources */,
 				8A06D6FC28EC30A7001CB63D /* JSONEncodableMocks.swift in Sources */,
-				8A0E4D5B29133F65008F7964 /* SearchSuggestionsVMCombineTests.swift in Sources */,
+				8A0E4D5B29133F65008F7964 /* WebSearchAutocompleteTests.swift in Sources */,
 				8A7B1BA728EB131F004FC135 /* WebViewVMCombineTests.swift in Sources */,
 				8A06D6FA28EC2FC8001CB63D /* ReachabilityAdapteeMocks.swift in Sources */,
 				8ACE7BEA28ED4F10001CBAED /* DNSResolvingStrategyMocks.swift in Sources */,

--- a/catowser/catowser.xcodeproj/project.pbxproj
+++ b/catowser/catowser.xcodeproj/project.pbxproj
@@ -938,6 +938,7 @@
 		755E10B027CA7C7D00D90AD0 /* LocalFeatureSource+BasicValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalFeatureSource+BasicValues.swift"; sourceTree = "<group>"; };
 		755E10B327CA7C8900D90AD0 /* LocalFeatureSource+EnumValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalFeatureSource+EnumValues.swift"; sourceTree = "<group>"; };
 		755E10B627CA81B600D90AD0 /* SpecificApplicationEnumFeatures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecificApplicationEnumFeatures.swift; sourceTree = "<group>"; };
+		759AE09529146C96008CE4EE /* Mockfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Mockfile; sourceTree = "<group>"; };
 		75DAB6DA280C44F0005F67FE /* CoreHttpKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = CoreHttpKit; path = ../CoreHttpKit/CoreHttpKit; sourceTree = "<group>"; };
 		841022B8224781A20021516F /* LinkTagsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkTagsViewController.swift; sourceTree = "<group>"; };
 		841022BC224785340021516F /* LinksBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinksBadgeView.swift; sourceTree = "<group>"; };
@@ -1625,6 +1626,7 @@
 				8A1C1BD4280B1D9E009B9363 /* Packages */,
 				60D52D26225CAE0300CB56F0 /* catowser.entitlements */,
 				8A8035E824442F45000E035F /* catowser dnsextDebug.entitlements */,
+				759AE09529146C96008CE4EE /* Mockfile */,
 				8435A4991EED5E700020102F /* catowser */,
 				6094E71D221FD2B9004269A2 /* CoreBrowser */,
 				8A7B1B9928EB131F004FC135 /* CoreCatowser */,
@@ -2525,10 +2527,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8A7B1BB228EB131F004FC135 /* Build configuration list for PBXNativeTarget "CoreCatowserTests" */;
 			buildPhases = (
+				8A03F43F28F4747900E4A296 /* ShellScript */,
 				8A7B1B9B28EB131F004FC135 /* Sources */,
 				8A7B1B9C28EB131F004FC135 /* Frameworks */,
 				8A7B1B9D28EB131F004FC135 /* Resources */,
-				8A03F43F28F4747900E4A296 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -2756,12 +2758,10 @@
 					608DA749223A3BD4009F75BD = {
 						CreatedOnToolsVersion = 10.1;
 						LastSwiftMigration = 1100;
-						ProvisioningStyle = Automatic;
 					};
 					6094E71B221FD2B9004269A2 = {
 						CreatedOnToolsVersion = 10.1;
 						LastSwiftMigration = 1100;
-						ProvisioningStyle = Automatic;
 					};
 					8435A4961EED5E700020102F = {
 						CreatedOnToolsVersion = 9.0;
@@ -2810,7 +2810,6 @@
 					8AE6D1682350FF35006316AD = {
 						CreatedOnToolsVersion = 10.2.1;
 						LastSwiftMigration = 1020;
-						ProvisioningStyle = Automatic;
 					};
 					8AF43374248EBB2A0047452B = {
 						CreatedOnToolsVersion = 11.5;
@@ -3131,10 +3130,11 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"$(PROJECT_DIR)/CoreCatowserTests/Mock.generated.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export PATH=\"$PATH:~/.mint/bin\"\n\nswiftymocky doctor    # validate your setup\nswiftymocky generate  # generate mocks\n";
+			shellScript = "export PATH=\"$PATH:~/.mint/bin\"\n\nif which swiftymocky > /dev/null; then\n  swiftlint\nelse\n  echo \"warning: swiftymocky not installed, run make\"\nfi\nswiftymocky doctor    # validate your setup\nswiftymocky generate  # generate mocks\n";
 		};
 		8A8035E224442F0F000E035F /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -4020,10 +4020,10 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_COMPLETION_HANDLER_MISUSE = YES;
 				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = ERT5B59458;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -4039,6 +4039,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ae.JSPlugins;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
@@ -4058,10 +4059,10 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_COMPLETION_HANDLER_MISUSE = YES;
 				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = ERT5B59458;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -4076,6 +4077,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ae.JSPlugins;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
@@ -4093,10 +4095,10 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_COMPLETION_HANDLER_MISUSE = YES;
 				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = ERT5B59458;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -4111,6 +4113,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ae.CoreBrowser;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
@@ -4128,10 +4131,10 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_COMPLETION_HANDLER_MISUSE = YES;
 				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = ERT5B59458;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -4145,6 +4148,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ae.CoreBrowser;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
@@ -4350,10 +4354,10 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = "$(inherited)";
 				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = ERT5B59458;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -4369,6 +4373,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ae.BrowserNetworking.debug;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
@@ -4575,9 +4580,10 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_OBJC_WEAK = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = ERT5B59458;
+				DEVELOPMENT_TEAM = "";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -4586,6 +4592,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ae.CoreCatowserTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = macosx;
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -4600,7 +4607,8 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_OBJC_WEAK = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -4621,9 +4629,9 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CLANG_ENABLE_OBJC_WEAK = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = ERT5B59458;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4637,6 +4645,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ae.HttpKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -4779,8 +4788,8 @@
 			buildSettings = {
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = ERT5B59458;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = CoreBrowserTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4793,6 +4802,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ae.CoreBrowserTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -4832,10 +4842,10 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = ERT5B59458;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -4853,6 +4863,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ae.ReactiveHttpKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
@@ -4871,10 +4882,10 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = ERT5B59458;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -4891,6 +4902,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ae.ReactiveHttpKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
@@ -4909,10 +4921,10 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = ERT5B59458;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -4930,6 +4942,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ae.FeaturesFlagsKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
@@ -4948,10 +4961,10 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = ERT5B59458;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -4968,6 +4981,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ae.FeaturesFlagsKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
@@ -4984,8 +4998,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_WEAK = YES;
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = ERT5B59458;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = JSPluginsTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4998,6 +5012,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ae.JSPluginsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -5037,10 +5052,10 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_COMPLETION_HANDLER_MISUSE = YES;
 				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = ERT5B59458;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -5056,6 +5071,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ae.HttpKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
@@ -5075,10 +5091,10 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_COMPLETION_HANDLER_MISUSE = YES;
 				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = ERT5B59458;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -5093,6 +5109,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ae.HttpKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
@@ -5110,10 +5127,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = ERT5B59458;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -5130,7 +5147,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.ae.CssParser.debug;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;

--- a/catowser/catowser.xcodeproj/project.pbxproj
+++ b/catowser/catowser.xcodeproj/project.pbxproj
@@ -129,7 +129,7 @@
 		8A1115EC24837DA400E63114 /* TabAddPositionsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1115EA24837DA400E63114 /* TabAddPositionsModel.swift */; };
 		8A1A1CE727B1966E0052A2A3 /* AlamofireHTTPRxAdaptee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB0D4102755075700493EC3 /* AlamofireHTTPRxAdaptee.swift */; };
 		8A1A1CE827B196B80052A2A3 /* AuthChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A978D4823F34909007ECB0C /* AuthChallenge.swift */; };
-		8A1C1BD9280B1E2D009B9363 /* HttpClient+Kotlin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1C1BD8280B1E2D009B9363 /* HttpClient+Kotlin.swift */; };
+		8A1C1BD9280B1E2D009B9363 /* RestClient+Kotlin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1C1BD8280B1E2D009B9363 /* RestClient+Kotlin.swift */; };
 		8A1C1C172484E5900098F2F1 /* TabDefaultContentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1C1C162484E5900098F2F1 /* TabDefaultContentModel.swift */; };
 		8A1C1C182484E5900098F2F1 /* TabDefaultContentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1C1C162484E5900098F2F1 /* TabDefaultContentModel.swift */; };
 		8A1C1C1A2484E6450098F2F1 /* TabDefaultContentViewPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1C1C192484E6450098F2F1 /* TabDefaultContentViewPreview.swift */; };
@@ -168,7 +168,7 @@
 		8A27722E268E4AD400D8878C /* SearchEngine+OpenSearchParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7A968C24462E8700E035F8 /* SearchEngine+OpenSearchParser.swift */; };
 		8A328F3527B690980021F6B0 /* NetworkReachabilityAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A328F3427B690980021F6B0 /* NetworkReachabilityAdapter.swift */; };
 		8A328F3927B695490021F6B0 /* AlamofireReachabilityAdaptee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A328F3827B695490021F6B0 /* AlamofireReachabilityAdaptee.swift */; };
-		8A41A18126738949005DAC7D /* HttpClient+URLSessionTaskDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A41A18026738949005DAC7D /* HttpClient+URLSessionTaskDelegate.swift */; };
+		8A41A18126738949005DAC7D /* RestClient+URLSessionTaskDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A41A18026738949005DAC7D /* RestClient+URLSessionTaskDelegate.swift */; };
 		8A437DA5247E7210001C1E8B /* UIHostingController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A437DA4247E7210001C1E8B /* UIHostingController+Extension.swift */; };
 		8A437DA6247E7210001C1E8B /* UIHostingController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A437DA4247E7210001C1E8B /* UIHostingController+Extension.swift */; };
 		8A437DA9247ED376001C1E8B /* TrimmedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A437DA8247ED376001C1E8B /* TrimmedString.swift */; };
@@ -309,8 +309,8 @@
 		8A8035F724446234000E035F /* DNSProxy.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 8A8035EF24446234000E035F /* DNSProxy.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		8A815D3B28F15EC5007A6926 /* WebViewVmJSPluginsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A815D3A28F15EC5007A6926 /* WebViewVmJSPluginsTests.swift */; };
 		8A815D3D28F16367007A6926 /* JSPluginsProgramImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A815D3C28F16367007A6926 /* JSPluginsProgramImpl.swift */; };
-		8A82CDF02351095700607162 /* HttpClientImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A82CDEF2351095700607162 /* HttpClientImpl.swift */; };
-		8A84DC562677867E000C69DB /* HttpClient+URLSessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A84DC552677867E000C69DB /* HttpClient+URLSessionDelegate.swift */; };
+		8A82CDF02351095700607162 /* RestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A82CDEF2351095700607162 /* RestClient.swift */; };
+		8A84DC562677867E000C69DB /* RestClient+URLSessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A84DC552677867E000C69DB /* RestClient+URLSessionDelegate.swift */; };
 		8A8EB007245EA1BA0028D35C /* WebViewAuthChallengeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8EB006245EA1B90028D35C /* WebViewAuthChallengeHandler.swift */; };
 		8A8EB008245EA1BA0028D35C /* WebViewAuthChallengeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8EB006245EA1B90028D35C /* WebViewAuthChallengeHandler.swift */; };
 		8A90636924332376009D786E /* URL+CoreExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A90636824332376009D786E /* URL+CoreExtensions.swift */; };
@@ -392,9 +392,9 @@
 		8ABA3CD62522608000E304E2 /* Database.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABA3CD42522608000E304E2 /* Database.swift */; };
 		8ABA3CD82522623200E304E2 /* TabsResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABA3CD72522623200E304E2 /* TabsResource.swift */; };
 		8ABA3CD92522623200E304E2 /* TabsResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABA3CD72522623200E304E2 /* TabsResource.swift */; };
-		8ABABEF1267233D3000AA9CB /* HttpClient+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABABEF0267233D3000AA9CB /* HttpClient+AsyncAwait.swift */; };
+		8ABABEF1267233D3000AA9CB /* RestClient+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABABEF0267233D3000AA9CB /* RestClient+AsyncAwait.swift */; };
 		8ABDB0B127B24E3900D6EDE7 /* Downloadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A74188B245086330019695E /* Downloadable.swift */; };
-		8ABDB0B427B24FB300D6EDE7 /* HttpClient+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC45ECC2458327D007E47EE /* HttpClient+Combine.swift */; };
+		8ABDB0B427B24FB300D6EDE7 /* RestClient+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC45ECC2458327D007E47EE /* RestClient+Combine.swift */; };
 		8ABDB0B627B269D500D6EDE7 /* HttpClient+Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA4FFF227A006CD003C3BBA /* HttpClient+Alamofire.swift */; };
 		8ABDB0B827B26A5C00D6EDE7 /* JSONEncodableMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABDB0B727B26A5C00D6EDE7 /* JSONEncodableMocks.swift */; };
 		8ABDB0BA27B2B6F200D6EDE7 /* HTTPAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABDB0B927B2B6F200D6EDE7 /* HTTPAdapter.swift */; };
@@ -474,7 +474,6 @@
 		8AE6D16D2350FF35006316AD /* HttpKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AE6D16B2350FF35006316AD /* HttpKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8AE8D045280D388800FADE3A /* ResponseType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE8D044280D388800FADE3A /* ResponseType.swift */; };
 		8AE8D048280D3CB500FADE3A /* HttpKotlinTypes+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE8D047280D3CB500FADE3A /* HttpKotlinTypes+Extensions.swift */; };
-		8AEA9454290E6DA100CCBB46 /* Mock.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEA9453290E6DA000CCBB46 /* Mock.generated.swift */; };
 		8AEDCE6828F02E41008516FD /* WebViewVmDNSoverHTTPSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEDCE6728F02E41008516FD /* WebViewVmDNSoverHTTPSTests.swift */; };
 		8AF4336C248E129F0047452B /* HTMLContentMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF4336B248E129F0047452B /* HTMLContentMessage.swift */; };
 		8AF4336F248EA3BE0047452B /* CSSBackgroundImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF4336E248EA3BE0047452B /* CSSBackgroundImage.swift */; };
@@ -484,7 +483,7 @@
 		8AF43384248EBBA70047452B /* Scanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF43381248EBBA70047452B /* Scanner.swift */; };
 		8AF43385248EBBA70047452B /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF43382248EBBA70047452B /* Parser.swift */; };
 		8AF43386248EBBA70047452B /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF43383248EBBA70047452B /* Token.swift */; };
-		8AF4922B235248CE00183579 /* HttpKitErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF4922A235248CE00183579 /* HttpKitErrors.swift */; };
+		8AF4922B235248CE00183579 /* RestClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF4922A235248CE00183579 /* RestClientError.swift */; };
 		C22599631F7BEF6D000E4C3A /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22599621F7BEF6D000E4C3A /* WebViewController.swift */; };
 		C22599671F7BF301000E4C3A /* MainBrowserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22599661F7BF301000E4C3A /* MainBrowserViewController.swift */; };
 		C27371171F7A341900900F03 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = C27371191F7A341900900F03 /* Localizable.strings */; };
@@ -967,7 +966,7 @@
 		8A1115EA24837DA400E63114 /* TabAddPositionsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabAddPositionsModel.swift; sourceTree = "<group>"; };
 		8A16102828947C2F00D45228 /* DNSResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DNSResolver.swift; sourceTree = "<group>"; };
 		8A16102E28947D2100D45228 /* DNSResolvingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DNSResolvingStrategy.swift; sourceTree = "<group>"; };
-		8A1C1BD8280B1E2D009B9363 /* HttpClient+Kotlin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HttpClient+Kotlin.swift"; sourceTree = "<group>"; };
+		8A1C1BD8280B1E2D009B9363 /* RestClient+Kotlin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RestClient+Kotlin.swift"; sourceTree = "<group>"; };
 		8A1C1C162484E5900098F2F1 /* TabDefaultContentModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabDefaultContentModel.swift; sourceTree = "<group>"; };
 		8A1C1C192484E6450098F2F1 /* TabDefaultContentViewPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabDefaultContentViewPreview.swift; sourceTree = "<group>"; };
 		8A1C1C1C24850F3F0098F2F1 /* WebViewController+SiteNavigationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebViewController+SiteNavigationDelegate.swift"; sourceTree = "<group>"; };
@@ -993,7 +992,7 @@
 		8A328F3827B695490021F6B0 /* AlamofireReachabilityAdaptee.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlamofireReachabilityAdaptee.swift; sourceTree = "<group>"; };
 		8A3FED7B288FC8CA004997E4 /* WebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewModel.swift; sourceTree = "<group>"; };
 		8A3FED7E288FD1A6004997E4 /* WebViewModelImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewModelImpl.swift; sourceTree = "<group>"; };
-		8A41A18026738949005DAC7D /* HttpClient+URLSessionTaskDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HttpClient+URLSessionTaskDelegate.swift"; sourceTree = "<group>"; };
+		8A41A18026738949005DAC7D /* RestClient+URLSessionTaskDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RestClient+URLSessionTaskDelegate.swift"; sourceTree = "<group>"; };
 		8A437DA4247E7210001C1E8B /* UIHostingController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIHostingController+Extension.swift"; sourceTree = "<group>"; };
 		8A437DA8247ED376001C1E8B /* TrimmedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrimmedString.swift; sourceTree = "<group>"; };
 		8A46AB9C2377260300DC03E6 /* GoogleDnsServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleDnsServer.swift; sourceTree = "<group>"; };
@@ -1042,8 +1041,8 @@
 		8A8035FC24449C9D000E035F /* GoogleSearchEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleSearchEngine.swift; sourceTree = "<group>"; };
 		8A815D3A28F15EC5007A6926 /* WebViewVmJSPluginsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewVmJSPluginsTests.swift; sourceTree = "<group>"; };
 		8A815D3C28F16367007A6926 /* JSPluginsProgramImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSPluginsProgramImpl.swift; sourceTree = "<group>"; };
-		8A82CDEF2351095700607162 /* HttpClientImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpClientImpl.swift; sourceTree = "<group>"; };
-		8A84DC552677867E000C69DB /* HttpClient+URLSessionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HttpClient+URLSessionDelegate.swift"; sourceTree = "<group>"; };
+		8A82CDEF2351095700607162 /* RestClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestClient.swift; sourceTree = "<group>"; };
+		8A84DC552677867E000C69DB /* RestClient+URLSessionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RestClient+URLSessionDelegate.swift"; sourceTree = "<group>"; };
 		8A8EB006245EA1B90028D35C /* WebViewAuthChallengeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewAuthChallengeHandler.swift; sourceTree = "<group>"; };
 		8A90636824332376009D786E /* URL+CoreExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+CoreExtensions.swift"; sourceTree = "<group>"; };
 		8A9069D9267F52BE0058F12D /* GoogleJSONDNSoHTTPsEndpoint+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GoogleJSONDNSoHTTPsEndpoint+AsyncAwait.swift"; sourceTree = "<group>"; };
@@ -1102,7 +1101,7 @@
 		8ABA3CD12522602900E304E2 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		8ABA3CD42522608000E304E2 /* Database.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database.swift; sourceTree = "<group>"; };
 		8ABA3CD72522623200E304E2 /* TabsResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsResource.swift; sourceTree = "<group>"; };
-		8ABABEF0267233D3000AA9CB /* HttpClient+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HttpClient+AsyncAwait.swift"; sourceTree = "<group>"; };
+		8ABABEF0267233D3000AA9CB /* RestClient+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RestClient+AsyncAwait.swift"; sourceTree = "<group>"; };
 		8ABDB0B727B26A5C00D6EDE7 /* JSONEncodableMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONEncodableMocks.swift; sourceTree = "<group>"; };
 		8ABDB0B927B2B6F200D6EDE7 /* HTTPAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPAdapter.swift; sourceTree = "<group>"; };
 		8ABDD90727CCF4360028B9DE /* FeatureManager+SpecificEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeatureManager+SpecificEnums.swift"; sourceTree = "<group>"; };
@@ -1110,7 +1109,7 @@
 		8ABF504027CC1A64007C6427 /* FeaturesFlagsKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FeaturesFlagsKit.h; sourceTree = "<group>"; };
 		8AC19CC0289E2F7E0021D8ED /* GoogleDNSStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleDNSStrategy.swift; sourceTree = "<group>"; };
 		8AC19CC3289E68F90021D8ED /* DNSResolver+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DNSResolver+AsyncAwait.swift"; sourceTree = "<group>"; };
-		8AC45ECC2458327D007E47EE /* HttpClient+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HttpClient+Combine.swift"; sourceTree = "<group>"; };
+		8AC45ECC2458327D007E47EE /* RestClient+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RestClient+Combine.swift"; sourceTree = "<group>"; };
 		8AC5873B289C3DA00038A7B5 /* WebViewContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewContext.swift; sourceTree = "<group>"; };
 		8AC6972628BB35DE00981BBF /* Host+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Host+Extension.swift"; sourceTree = "<group>"; };
 		8AC6D5F828F008EC008379C0 /* NavigationActionableMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationActionableMocks.swift; sourceTree = "<group>"; };
@@ -1140,7 +1139,6 @@
 		8AE6D16C2350FF35006316AD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8AE8D044280D388800FADE3A /* ResponseType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseType.swift; sourceTree = "<group>"; };
 		8AE8D047280D3CB500FADE3A /* HttpKotlinTypes+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HttpKotlinTypes+Extensions.swift"; sourceTree = "<group>"; };
-		8AEA9453290E6DA000CCBB46 /* Mock.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mock.generated.swift; sourceTree = "<group>"; };
 		8AEDCE6728F02E41008516FD /* WebViewVmDNSoverHTTPSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewVmDNSoverHTTPSTests.swift; sourceTree = "<group>"; };
 		8AF0B95728B9FA2C001D202C /* WebViewModelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewModelState.swift; sourceTree = "<group>"; };
 		8AF0B95A28B9FA8A001D202C /* WebViewModelState+Actionable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebViewModelState+Actionable.swift"; sourceTree = "<group>"; };
@@ -1153,7 +1151,7 @@
 		8AF43381248EBBA70047452B /* Scanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Scanner.swift; sourceTree = "<group>"; };
 		8AF43382248EBBA70047452B /* Parser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
 		8AF43383248EBBA70047452B /* Token.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Token.swift; sourceTree = "<group>"; };
-		8AF4922A235248CE00183579 /* HttpKitErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpKitErrors.swift; sourceTree = "<group>"; };
+		8AF4922A235248CE00183579 /* RestClientError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestClientError.swift; sourceTree = "<group>"; };
 		C22599621F7BEF6D000E4C3A /* WebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
 		C22599661F7BF301000E4C3A /* MainBrowserViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainBrowserViewController.swift; sourceTree = "<group>"; };
 		C27371181F7A341900900F03 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1839,7 +1837,6 @@
 		8A5E6C75290B0C430034A78B /* GeneratedMocks */ = {
 			isa = PBXGroup;
 			children = (
-				8AEA9453290E6DA000CCBB46 /* Mock.generated.swift */,
 			);
 			path = GeneratedMocks;
 			sourceTree = "<group>";
@@ -2208,15 +2205,15 @@
 				8AB4A1B427B55684008030FB /* HTTPVoidAdapter.swift */,
 				8A328F3427B690980021F6B0 /* NetworkReachabilityAdapter.swift */,
 				8A5E6CAE290B1D4F0034A78B /* RestInterface.swift */,
-				8A82CDEF2351095700607162 /* HttpClientImpl.swift */,
+				8A82CDEF2351095700607162 /* RestClient.swift */,
 				8AB4A1AB27B53043008030FB /* ClientSubscriber.swift */,
 				8ACAE08E27B7DF52001D9DCD /* DummyRxInterface.swift */,
-				8AC45ECC2458327D007E47EE /* HttpClient+Combine.swift */,
-				8ABABEF0267233D3000AA9CB /* HttpClient+AsyncAwait.swift */,
-				8A41A18026738949005DAC7D /* HttpClient+URLSessionTaskDelegate.swift */,
-				8A1C1BD8280B1E2D009B9363 /* HttpClient+Kotlin.swift */,
-				8A84DC552677867E000C69DB /* HttpClient+URLSessionDelegate.swift */,
-				8AF4922A235248CE00183579 /* HttpKitErrors.swift */,
+				8AC45ECC2458327D007E47EE /* RestClient+Combine.swift */,
+				8ABABEF0267233D3000AA9CB /* RestClient+AsyncAwait.swift */,
+				8A41A18026738949005DAC7D /* RestClient+URLSessionTaskDelegate.swift */,
+				8A1C1BD8280B1E2D009B9363 /* RestClient+Kotlin.swift */,
+				8A84DC552677867E000C69DB /* RestClient+URLSessionDelegate.swift */,
+				8AF4922A235248CE00183579 /* RestClientError.swift */,
 				8AE8D044280D388800FADE3A /* ResponseType.swift */,
 			);
 			path = HttpKit;
@@ -3515,7 +3512,6 @@
 				8A06D6FA28EC2FC8001CB63D /* ReachabilityAdapteeMocks.swift in Sources */,
 				8ACE7BEA28ED4F10001CBAED /* DNSResolvingStrategyMocks.swift in Sources */,
 				8AC6D5F928F008EC008379C0 /* NavigationActionableMocks.swift in Sources */,
-				8AEA9454290E6DA100CCBB46 /* Mock.generated.swift in Sources */,
 				8A06D6F728EC2CF8001CB63D /* ServerDescriptionMocks.swift in Sources */,
 				8A06D6F528EC2C5D001CB63D /* ResponseTypeMocks.swift in Sources */,
 				8ACE7BEC28ED4FC9001CBAED /* WebViewContextMocks.swift in Sources */,
@@ -3690,18 +3686,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8AF4922B235248CE00183579 /* HttpKitErrors.swift in Sources */,
-				8ABABEF1267233D3000AA9CB /* HttpClient+AsyncAwait.swift in Sources */,
-				8A1C1BD9280B1E2D009B9363 /* HttpClient+Kotlin.swift in Sources */,
+				8AF4922B235248CE00183579 /* RestClientError.swift in Sources */,
+				8ABABEF1267233D3000AA9CB /* RestClient+AsyncAwait.swift in Sources */,
+				8A1C1BD9280B1E2D009B9363 /* RestClient+Kotlin.swift in Sources */,
 				8ABDB0BA27B2B6F200D6EDE7 /* HTTPAdapter.swift in Sources */,
 				8AB4A1AF27B5522B008030FB /* ClosureWrappers.swift in Sources */,
-				8A82CDF02351095700607162 /* HttpClientImpl.swift in Sources */,
+				8A82CDF02351095700607162 /* RestClient.swift in Sources */,
 				8AB4A1AD27B5335C008030FB /* ClientSubscriber.swift in Sources */,
 				8A7A9BAC23F1C477008850B6 /* URL+Extensions.swift in Sources */,
 				8AB4A1B127B55268008030FB /* ResponseHandlingApiType.swift in Sources */,
-				8A84DC562677867E000C69DB /* HttpClient+URLSessionDelegate.swift in Sources */,
+				8A84DC562677867E000C69DB /* RestClient+URLSessionDelegate.swift in Sources */,
 				8AB5B3C4280C8B3D001F8644 /* RequestInterfaces.swift in Sources */,
-				8ABDB0B427B24FB300D6EDE7 /* HttpClient+Combine.swift in Sources */,
+				8ABDB0B427B24FB300D6EDE7 /* RestClient+Combine.swift in Sources */,
 				8A68E40E245966190070F338 /* CombineExtensions.swift in Sources */,
 				8ACAE08F27B7DF52001D9DCD /* DummyRxInterface.swift in Sources */,
 				8AB4A1B927B583AB008030FB /* ClosureVoidWrappers.swift in Sources */,
@@ -3709,7 +3705,7 @@
 				8AB4A1B527B55684008030FB /* HTTPVoidAdapter.swift in Sources */,
 				8AB5B3C6280C92B1001F8644 /* HttpKotlinTypes+Extensions.swift in Sources */,
 				8A328F3527B690980021F6B0 /* NetworkReachabilityAdapter.swift in Sources */,
-				8A41A18126738949005DAC7D /* HttpClient+URLSessionTaskDelegate.swift in Sources */,
+				8A41A18126738949005DAC7D /* RestClient+URLSessionTaskDelegate.swift in Sources */,
 				8AB4A1B727B56CC3008030FB /* ResponseVoidHandlingApiType.swift in Sources */,
 				8AE8D045280D388800FADE3A /* ResponseType.swift in Sources */,
 			);

--- a/catowser/catowser.xcodeproj/project.pbxproj
+++ b/catowser/catowser.xcodeproj/project.pbxproj
@@ -461,6 +461,9 @@
 		8AD4F54128F4936B009C4BDC /* ReactiveHttpKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8AB70E9127B7AE7A003FB59B /* ReactiveHttpKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8AD4F54528F493B8009C4BDC /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 8AD4F54428F493B8009C4BDC /* Alamofire */; };
 		8AD4F54728F4941A009C4BDC /* ReactiveSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 8AD4F54628F4941A009C4BDC /* ReactiveSwift */; };
+		8AD5E03E29153F6200901DA2 /* SearchSuggestionsVMCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD5E03D29153F6200901DA2 /* SearchSuggestionsVMCombineTests.swift */; };
+		8AD5E0402915485200901DA2 /* SearchViewContextImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD5E03F2915485200901DA2 /* SearchViewContextImpl.swift */; };
+		8AD5E0412915485200901DA2 /* SearchViewContextImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD5E03F2915485200901DA2 /* SearchViewContextImpl.swift */; };
 		8AD62B7928F55079003F3940 /* AutoMockable.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD62B7828F55078003F3940 /* AutoMockable.generated.swift */; };
 		8AD62B7A28F564B8003F3940 /* CoreBrowser.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6094E71C221FD2B9004269A2 /* CoreBrowser.framework */; };
 		8AD8A169245D6F7400BE8070 /* WebViewLoadingErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD8A168245D6F7400BE8070 /* WebViewLoadingErrorHandler.swift */; };
@@ -1126,6 +1129,8 @@
 		8ACE7BED28ED6E0F001CBAED /* WebViewMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewMocks.swift; sourceTree = "<group>"; };
 		8AD18E0F2447580A00224702 /* ResourceReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceReader.swift; sourceTree = "<group>"; };
 		8AD2CEE62444DD7C00FFCBC7 /* duckduckgo.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = duckduckgo.xml; sourceTree = "<group>"; };
+		8AD5E03D29153F6200901DA2 /* SearchSuggestionsVMCombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSuggestionsVMCombineTests.swift; sourceTree = "<group>"; };
+		8AD5E03F2915485200901DA2 /* SearchViewContextImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewContextImpl.swift; sourceTree = "<group>"; };
 		8AD62B6F28F547E6003F3940 /* Sourcery */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Sourcery; sourceTree = "<group>"; };
 		8AD62B7828F55078003F3940 /* AutoMockable.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoMockable.generated.swift; sourceTree = "<group>"; };
 		8AD8A168245D6F7400BE8070 /* WebViewLoadingErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewLoadingErrorHandler.swift; sourceTree = "<group>"; };
@@ -1575,6 +1580,7 @@
 				841A2D83203AD5690050A996 /* SmartphoneSearchBarViewController.swift */,
 				841A2D85203B1FA50050A996 /* SearchBarBaseViewController.swift */,
 				C707CC11203F0BAF002EA258 /* SearchSuggestionsViewController.swift */,
+				8AD5E03F2915485200901DA2 /* SearchViewContextImpl.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -1910,6 +1916,7 @@
 				8AEDCE6728F02E41008516FD /* WebViewVmDNSoverHTTPSTests.swift */,
 				8A815D3A28F15EC5007A6926 /* WebViewVmJSPluginsTests.swift */,
 				8AB9BE0928FEB17E002063C2 /* WebSearchAutocompleteTests.swift */,
+				8AD5E03D29153F6200901DA2 /* SearchSuggestionsVMCombineTests.swift */,
 				8A5E6C75290B0C430034A78B /* GeneratedMocks */,
 				8A06D6F828EC2FB6001CB63D /* Mocks */,
 			);
@@ -3377,6 +3384,7 @@
 				755E107127BC3DC500D90AD0 /* AppAsyncApiTypeViewPreview.swift in Sources */,
 				755E10B727CA81B600D90AD0 /* SpecificApplicationEnumFeatures.swift in Sources */,
 				841A2D84203AD5690050A996 /* SmartphoneSearchBarViewController.swift in Sources */,
+				8AD5E0402915485200901DA2 /* SearchViewContextImpl.swift in Sources */,
 				8AB9BE2228FF0D5C002063C2 /* Tab+Extension.swift in Sources */,
 				605C54F721F8A9E900B3DC73 /* TabPreviewCell.swift in Sources */,
 				60C2C90522801F3400F5D869 /* SiteCollectionViewCell.swift in Sources */,
@@ -3519,6 +3527,7 @@
 				8AEDCE6828F02E41008516FD /* WebViewVmDNSoverHTTPSTests.swift in Sources */,
 				8A815D3B28F15EC5007A6926 /* WebViewVmJSPluginsTests.swift in Sources */,
 				8A06D6FC28EC30A7001CB63D /* JSONEncodableMocks.swift in Sources */,
+				8AD5E03E29153F6200901DA2 /* SearchSuggestionsVMCombineTests.swift in Sources */,
 				8A0E4D5B29133F65008F7964 /* WebSearchAutocompleteTests.swift in Sources */,
 				8A7B1BA728EB131F004FC135 /* WebViewVMCombineTests.swift in Sources */,
 				8A06D6FA28EC2FC8001CB63D /* ReachabilityAdapteeMocks.swift in Sources */,
@@ -3572,6 +3581,7 @@
 				755E107227BC3DC500D90AD0 /* AppAsyncApiTypeViewPreview.swift in Sources */,
 				755E10B827CA81B600D90AD0 /* SpecificApplicationEnumFeatures.swift in Sources */,
 				8A8035B524442F0F000E035F /* SmartphoneSearchBarViewController.swift in Sources */,
+				8AD5E0412915485200901DA2 /* SearchViewContextImpl.swift in Sources */,
 				8AB9BE2328FF0D5C002063C2 /* Tab+Extension.swift in Sources */,
 				8A8035B624442F0F000E035F /* TabPreviewCell.swift in Sources */,
 				8A8035B724442F0F000E035F /* SiteCollectionViewCell.swift in Sources */,

--- a/catowser/catowser.xcodeproj/project.pbxproj
+++ b/catowser/catowser.xcodeproj/project.pbxproj
@@ -177,6 +177,14 @@
 		8A55351B247D740900E3B330 /* SiteMenuModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A553519247D740900E3B330 /* SiteMenuModel.swift */; };
 		8A566F7F245D7D7B00E71221 /* AlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A566F7E245D7D7B00E71221 /* AlertPresenter.swift */; };
 		8A566F80245D7D7B00E71221 /* AlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A566F7E245D7D7B00E71221 /* AlertPresenter.swift */; };
+		8A5E6C80290B0E6C0034A78B /* AutoMockable.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A5E6C7F290B0E6C0034A78B /* AutoMockable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A5E6C83290B0E6C0034A78B /* AutoMockable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A5E6C7D290B0E6C0034A78B /* AutoMockable.framework */; };
+		8A5E6C84290B0E6C0034A78B /* AutoMockable.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8A5E6C7D290B0E6C0034A78B /* AutoMockable.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8A5E6C88290B0E810034A78B /* AutoMockable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5E6C72290B06790034A78B /* AutoMockable.swift */; };
+		8A5E6C89290B0EAE0034A78B /* AutoMockable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A5E6C7D290B0E6C0034A78B /* AutoMockable.framework */; };
+		8A5E6C8E290B0ED10034A78B /* AutoMockable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A5E6C7D290B0E6C0034A78B /* AutoMockable.framework */; };
+		8A5E6C93290B107B0034A78B /* AutoMockable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A5E6C7D290B0E6C0034A78B /* AutoMockable.framework */; };
+		8A5E6C99290B11880034A78B /* Mock.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5E6C98290B11880034A78B /* Mock.generated.swift */; };
 		8A5F71F62826C148008E5638 /* CoreHttpKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A5F71F52826C148008E5638 /* CoreHttpKit.xcframework */; };
 		8A5F71F72826C148008E5638 /* CoreHttpKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8A5F71F52826C148008E5638 /* CoreHttpKit.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8A5F71F82826C183008E5638 /* CoreHttpKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A5F71F52826C148008E5638 /* CoreHttpKit.xcframework */; };
@@ -352,7 +360,6 @@
 		8AB70EA627B7B518003FB59B /* HTTPAdapter+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB70EA527B7B518003FB59B /* HTTPAdapter+Rx.swift */; };
 		8AB8018A27C3E597002D6628 /* BaseMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB8018927C3E597002D6628 /* BaseMenuView.swift */; };
 		8AB8018B27C3E597002D6628 /* BaseMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB8018927C3E597002D6628 /* BaseMenuView.swift */; };
-		8AB9BE0E28FEBA34002063C2 /* AutoMockable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB9BE0D28FEBA34002063C2 /* AutoMockable.swift */; };
 		8AB9BE0F28FEFD84002063C2 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 607CC66622A5505F0037E5EC /* UIKit.framework */; platformFilter = ios; };
 		8AB9BE1128FF0C23002063C2 /* UIViewController+CatowserExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6094E712221EC8D4004269A2 /* UIViewController+CatowserExtensions.swift */; };
 		8AB9BE1228FF0C23002063C2 /* UIViewController+CatowserExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6094E712221EC8D4004269A2 /* UIViewController+CatowserExtensions.swift */; };
@@ -518,6 +525,34 @@
 			proxyType = 1;
 			remoteGlobalIDString = 8A277136268E452000D8878C;
 			remoteInfo = BrowserNetworking;
+		};
+		8A5E6C81290B0E6C0034A78B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8435A48F1EED5E700020102F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8A5E6C7C290B0E6C0034A78B;
+			remoteInfo = AutoMockable;
+		};
+		8A5E6C8B290B0EAE0034A78B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8435A48F1EED5E700020102F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8A5E6C7C290B0E6C0034A78B;
+			remoteInfo = AutoMockable;
+		};
+		8A5E6C90290B0ED10034A78B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8435A48F1EED5E700020102F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8A5E6C7C290B0E6C0034A78B;
+			remoteInfo = AutoMockable;
+		};
+		8A5E6C95290B107B0034A78B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8435A48F1EED5E700020102F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8A5E6C7C290B0E6C0034A78B;
+			remoteInfo = AutoMockable;
 		};
 		8A5F72122826DD59008E5638 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -766,6 +801,7 @@
 				8ABF504527CC1A64007C6427 /* FeaturesFlagsKit.framework in Embed Frameworks */,
 				8A5F71F72826C148008E5638 /* CoreHttpKit.xcframework in Embed Frameworks */,
 				8A27713F268E452000D8878C /* BrowserNetworking.framework in Embed Frameworks */,
+				8A5E6C84290B0E6C0034A78B /* AutoMockable.framework in Embed Frameworks */,
 				8AF4337D248EBB2A0047452B /* CssParser.framework in Embed Frameworks */,
 				8A5FD6A526AF31FE0019384A /* HttpKit.framework in Embed Frameworks */,
 			);
@@ -963,6 +999,10 @@
 		8A553519247D740900E3B330 /* SiteMenuModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMenuModel.swift; sourceTree = "<group>"; };
 		8A566F7E245D7D7B00E71221 /* AlertPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertPresenter.swift; sourceTree = "<group>"; };
 		8A5755A928638748004D6F1E /* SearchSuggestionsViewModelImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSuggestionsViewModelImpl.swift; sourceTree = "<group>"; };
+		8A5E6C72290B06790034A78B /* AutoMockable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoMockable.swift; sourceTree = "<group>"; };
+		8A5E6C7D290B0E6C0034A78B /* AutoMockable.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AutoMockable.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8A5E6C7F290B0E6C0034A78B /* AutoMockable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AutoMockable.h; sourceTree = "<group>"; };
+		8A5E6C98290B11880034A78B /* Mock.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mock.generated.swift; sourceTree = "<group>"; };
 		8A5F71F52826C148008E5638 /* CoreHttpKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CoreHttpKit.xcframework; path = ../CoreHttpKit/build/XCFrameworks/release/CoreHttpKit.xcframework; sourceTree = "<group>"; };
 		8A5FD6A826AF34570019384A /* AppErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrors.swift; sourceTree = "<group>"; };
 		8A624074288D98DA006DDC66 /* SearchSuggestionsViewModelImpl+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchSuggestionsViewModelImpl+AsyncAwait.swift"; sourceTree = "<group>"; };
@@ -1054,7 +1094,6 @@
 		8AB70EA527B7B518003FB59B /* HTTPAdapter+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HTTPAdapter+Rx.swift"; sourceTree = "<group>"; };
 		8AB8018927C3E597002D6628 /* BaseMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseMenuView.swift; sourceTree = "<group>"; };
 		8AB9BE0928FEB17E002063C2 /* SearchSuggestionsVMCombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSuggestionsVMCombineTests.swift; sourceTree = "<group>"; };
-		8AB9BE0D28FEBA34002063C2 /* AutoMockable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoMockable.swift; sourceTree = "<group>"; };
 		8AB9BE2128FF0D5C002063C2 /* Tab+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tab+Extension.swift"; sourceTree = "<group>"; };
 		8AB9BE2428FF0FB1002063C2 /* TabsListManager+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabsListManager+Extension.swift"; sourceTree = "<group>"; };
 		8ABA3CCE2522601800E304E2 /* TabsDBClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsDBClient.swift; sourceTree = "<group>"; };
@@ -1140,6 +1179,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				60C2C92122819AE200F5D869 /* CoreImage.framework in Frameworks */,
+				8A5E6C89290B0EAE0034A78B /* AutoMockable.framework in Frameworks */,
 				8A5F71F82826C183008E5638 /* CoreHttpKit.xcframework in Frameworks */,
 				8AD4F51028F491A7009C4BDC /* ReactiveSwift in Frameworks */,
 			);
@@ -1154,6 +1194,7 @@
 				8AE31138247C666A00FF28B1 /* UIKit.framework in Frameworks */,
 				8A7B1BE828EB18A5004FC135 /* CoreCatowser.framework in Frameworks */,
 				8AD4F51E28F492DC009C4BDC /* AlamofireImage in Frameworks */,
+				8A5E6C83290B0E6C0034A78B /* AutoMockable.framework in Frameworks */,
 				8A5F71F62826C148008E5638 /* CoreHttpKit.xcframework in Frameworks */,
 				8AD4F51C28F49219009C4BDC /* ReactiveSwift in Frameworks */,
 				8ABF504427CC1A64007C6427 /* FeaturesFlagsKit.framework in Frameworks */,
@@ -1182,6 +1223,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		8A5E6C7A290B0E6C0034A78B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8A7B1B9528EB131E004FC135 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1190,6 +1238,7 @@
 				8A7B1BDC28EB1736004FC135 /* JSPlugins.framework in Frameworks */,
 				8A7B1BD128EB16F9004FC135 /* ReactiveHttpKit.framework in Frameworks */,
 				8AD4F51A28F49208009C4BDC /* ReactiveSwift in Frameworks */,
+				8A5E6C8E290B0ED10034A78B /* AutoMockable.framework in Frameworks */,
 				8A7B1BD528EB170E004FC135 /* Combine.framework in Frameworks */,
 				8A7B1BCC28EB16F4004FC135 /* HttpKit.framework in Frameworks */,
 				8A7B1BEF28EB18DB004FC135 /* CoreHttpKit.xcframework in Frameworks */,
@@ -1293,6 +1342,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8A5F720A2826C432008E5638 /* CoreHttpKit.xcframework in Frameworks */,
+				8A5E6C93290B107B0034A78B /* AutoMockable.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1576,6 +1626,7 @@
 				8A277138268E452000D8878C /* BrowserNetworking */,
 				8A8035F024446234000E035F /* DNSProxy */,
 				8AF43376248EBB2A0047452B /* CssParser */,
+				8A5E6C7E290B0E6C0034A78B /* AutoMockable */,
 				8A7EF3D2273924EF0071BB89 /* HttpKitTests */,
 				8AE63B55248EC38300D6D2E4 /* JSPluginsTests */,
 				8AB022ED26258B110053AFF0 /* CoreBrowserTests */,
@@ -1603,6 +1654,7 @@
 				8ABF503E27CC1A64007C6427 /* FeaturesFlagsKit.framework */,
 				8A7B1B9828EB131E004FC135 /* CoreCatowser.framework */,
 				8A7B1B9F28EB131F004FC135 /* CoreCatowserTests.xctest */,
+				8A5E6C7D290B0E6C0034A78B /* AutoMockable.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1780,6 +1832,23 @@
 			path = PropertyWrappers;
 			sourceTree = "<group>";
 		};
+		8A5E6C75290B0C430034A78B /* GeneratedMocks */ = {
+			isa = PBXGroup;
+			children = (
+				8A5E6C98290B11880034A78B /* Mock.generated.swift */,
+			);
+			path = GeneratedMocks;
+			sourceTree = "<group>";
+		};
+		8A5E6C7E290B0E6C0034A78B /* AutoMockable */ = {
+			isa = PBXGroup;
+			children = (
+				8A5E6C72290B06790034A78B /* AutoMockable.swift */,
+				8A5E6C7F290B0E6C0034A78B /* AutoMockable.h */,
+			);
+			path = AutoMockable;
+			sourceTree = "<group>";
+		};
 		8A62AEDA2351CDDB001A9C83 /* Servers */ = {
 			isa = PBXGroup;
 			children = (
@@ -1816,7 +1885,6 @@
 				8A5FD6A826AF34570019384A /* AppErrors.swift */,
 				8A964E3924867A9400A0AABE /* SiteSettings+Extensions.swift */,
 				8A7B1BFE28EB3269004FC135 /* Site+Extensions.swift */,
-				8AB9BE0D28FEBA34002063C2 /* AutoMockable.swift */,
 				8A7B1BC028EB1679004FC135 /* SearchViewModel */,
 				8A7B1BB328EB1512004FC135 /* WebViewModel */,
 			);
@@ -1830,6 +1898,7 @@
 				8AEDCE6728F02E41008516FD /* WebViewVmDNSoverHTTPSTests.swift */,
 				8A815D3A28F15EC5007A6926 /* WebViewVmJSPluginsTests.swift */,
 				8AB9BE0928FEB17E002063C2 /* SearchSuggestionsVMCombineTests.swift */,
+				8A5E6C75290B0C430034A78B /* GeneratedMocks */,
 				8A06D6F828EC2FB6001CB63D /* Mocks */,
 			);
 			path = CoreCatowserTests;
@@ -2234,6 +2303,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		8A5E6C78290B0E6C0034A78B /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8A5E6C80290B0E6C0034A78B /* AutoMockable.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8A7B1B9328EB131E004FC135 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -2314,6 +2391,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				8A5E6C8C290B0EAE0034A78B /* PBXTargetDependency */,
 			);
 			name = CoreBrowser;
 			packageProductDependencies = (
@@ -2346,6 +2424,7 @@
 				8A5F72132826DD59008E5638 /* PBXTargetDependency */,
 				8A7B1BAA28EB131F004FC135 /* PBXTargetDependency */,
 				8A7B1BEA28EB18A5004FC135 /* PBXTargetDependency */,
+				8A5E6C82290B0E6C0034A78B /* PBXTargetDependency */,
 			);
 			name = Cotton;
 			packageProductDependencies = (
@@ -2383,6 +2462,24 @@
 			productReference = 8A277137268E452000D8878C /* BrowserNetworking.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		8A5E6C7C290B0E6C0034A78B /* AutoMockable */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8A5E6C85290B0E6C0034A78B /* Build configuration list for PBXNativeTarget "AutoMockable" */;
+			buildPhases = (
+				8A5E6C78290B0E6C0034A78B /* Headers */,
+				8A5E6C79290B0E6C0034A78B /* Sources */,
+				8A5E6C7A290B0E6C0034A78B /* Frameworks */,
+				8A5E6C7B290B0E6C0034A78B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AutoMockable;
+			productName = AutoMockable;
+			productReference = 8A5E6C7D290B0E6C0034A78B /* AutoMockable.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		8A7B1B9728EB131E004FC135 /* CoreCatowser */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8A7B1BB128EB131F004FC135 /* Build configuration list for PBXNativeTarget "CoreCatowser" */;
@@ -2402,6 +2499,7 @@
 				8A7B1BDF28EB1736004FC135 /* PBXTargetDependency */,
 				8A7B1BE728EB1771004FC135 /* PBXTargetDependency */,
 				8AB9BE2F28FF149A002063C2 /* PBXTargetDependency */,
+				8A5E6C91290B0ED10034A78B /* PBXTargetDependency */,
 			);
 			name = CoreCatowser;
 			packageProductDependencies = (
@@ -2606,6 +2704,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				8A5E6C96290B107B0034A78B /* PBXTargetDependency */,
 			);
 			name = HttpKit;
 			productName = HttpKit;
@@ -2663,6 +2762,9 @@
 					};
 					8A277136268E452000D8878C = {
 						CreatedOnToolsVersion = 12.4;
+					};
+					8A5E6C7C290B0E6C0034A78B = {
+						CreatedOnToolsVersion = 14.0.1;
 					};
 					8A7B1B9728EB131E004FC135 = {
 						CreatedOnToolsVersion = 14.0;
@@ -2741,6 +2843,7 @@
 				8A7EF3D0273924EF0071BB89 /* HttpKitTests */,
 				8AB022EB26258B110053AFF0 /* CoreBrowserTests */,
 				8A7B1B9E28EB131F004FC135 /* CoreCatowserTests */,
+				8A5E6C7C290B0E6C0034A78B /* AutoMockable */,
 			);
 		};
 /* End PBXProject section */
@@ -2780,6 +2883,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		8A277135268E452000D8878C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8A5E6C7B290B0E6C0034A78B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3010,7 +3120,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftlint > /dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "export PATH=\"$PATH:~/.mint/bin\"\n\nswiftymocky doctor    # validate your setup\nswiftymocky generate  # generate mocks\n";
 		};
 		8A8035E224442F0F000E035F /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3348,6 +3458,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		8A5E6C79290B0E6C0034A78B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8A5E6C88290B0E810034A78B /* AutoMockable.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8A7B1B9428EB131E004FC135 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3375,7 +3493,6 @@
 				8A7B1BC428EB16C4004FC135 /* WebSearchAutocomplete.swift in Sources */,
 				8A7B1BC928EB16DA004FC135 /* DDGoAutocompleteStrategy.swift in Sources */,
 				8A7B1BBD28EB1619004FC135 /* DNSResolver+AsyncAwait.swift in Sources */,
-				8AB9BE0E28FEBA34002063C2 /* AutoMockable.swift in Sources */,
 				8A7B1BBA28EB15E2004FC135 /* WebViewModelImpl.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3392,6 +3509,7 @@
 				8A06D6FA28EC2FC8001CB63D /* ReachabilityAdapteeMocks.swift in Sources */,
 				8ACE7BEA28ED4F10001CBAED /* DNSResolvingStrategyMocks.swift in Sources */,
 				8AC6D5F928F008EC008379C0 /* NavigationActionableMocks.swift in Sources */,
+				8A5E6C99290B11880034A78B /* Mock.generated.swift in Sources */,
 				8A06D6F728EC2CF8001CB63D /* ServerDescriptionMocks.swift in Sources */,
 				8A06D6F528EC2C5D001CB63D /* ResponseTypeMocks.swift in Sources */,
 				8ACE7BEC28ED4FC9001CBAED /* WebViewContextMocks.swift in Sources */,
@@ -3628,6 +3746,26 @@
 			isa = PBXTargetDependency;
 			target = 8A277136268E452000D8878C /* BrowserNetworking */;
 			targetProxy = 8A27715F268E467D00D8878C /* PBXContainerItemProxy */;
+		};
+		8A5E6C82290B0E6C0034A78B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8A5E6C7C290B0E6C0034A78B /* AutoMockable */;
+			targetProxy = 8A5E6C81290B0E6C0034A78B /* PBXContainerItemProxy */;
+		};
+		8A5E6C8C290B0EAE0034A78B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8A5E6C7C290B0E6C0034A78B /* AutoMockable */;
+			targetProxy = 8A5E6C8B290B0EAE0034A78B /* PBXContainerItemProxy */;
+		};
+		8A5E6C91290B0ED10034A78B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8A5E6C7C290B0E6C0034A78B /* AutoMockable */;
+			targetProxy = 8A5E6C90290B0ED10034A78B /* PBXContainerItemProxy */;
+		};
+		8A5E6C96290B107B0034A78B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8A5E6C7C290B0E6C0034A78B /* AutoMockable */;
+			targetProxy = 8A5E6C95290B107B0034A78B /* PBXContainerItemProxy */;
 		};
 		8A5F72132826DD59008E5638 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -4253,6 +4391,85 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		8A5E6C86290B0E6C0034A78B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = ERT5B59458;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 andreiermoshin. All rights reserved.";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ae.AutoMockable;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		8A5E6C87290B0E6C0034A78B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = ERT5B59458;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 andreiermoshin. All rights reserved.";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ae.AutoMockable;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
@@ -4990,6 +5207,15 @@
 			buildConfigurations = (
 				8A277140268E452000D8878C /* Debug */,
 				8A277141268E452000D8878C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8A5E6C85290B0E6C0034A78B /* Build configuration list for PBXNativeTarget "AutoMockable" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8A5E6C86290B0E6C0034A78B /* Debug */,
+				8A5E6C87290B0E6C0034A78B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/catowser/catowser.xcodeproj/project.pbxproj
+++ b/catowser/catowser.xcodeproj/project.pbxproj
@@ -184,7 +184,9 @@
 		8A5E6C89290B0EAE0034A78B /* AutoMockable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A5E6C7D290B0E6C0034A78B /* AutoMockable.framework */; };
 		8A5E6C8E290B0ED10034A78B /* AutoMockable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A5E6C7D290B0E6C0034A78B /* AutoMockable.framework */; };
 		8A5E6C93290B107B0034A78B /* AutoMockable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A5E6C7D290B0E6C0034A78B /* AutoMockable.framework */; };
-		8A5E6C99290B11880034A78B /* Mock.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5E6C98290B11880034A78B /* Mock.generated.swift */; };
+		8A5E6CAF290B1D4F0034A78B /* RestInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5E6CAE290B1D4F0034A78B /* RestInterface.swift */; };
+		8A5E6CB1290B21B50034A78B /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 8A5E6CB0290B21B50034A78B /* Alamofire */; };
+		8A5E6CB3290B228B0034A78B /* Mock.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5E6CB2290B228B0034A78B /* Mock.generated.swift */; };
 		8A5F71F62826C148008E5638 /* CoreHttpKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A5F71F52826C148008E5638 /* CoreHttpKit.xcframework */; };
 		8A5F71F72826C148008E5638 /* CoreHttpKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8A5F71F52826C148008E5638 /* CoreHttpKit.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8A5F71F82826C183008E5638 /* CoreHttpKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A5F71F52826C148008E5638 /* CoreHttpKit.xcframework */; };
@@ -308,7 +310,7 @@
 		8A8035F724446234000E035F /* DNSProxy.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 8A8035EF24446234000E035F /* DNSProxy.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		8A815D3B28F15EC5007A6926 /* WebViewVmJSPluginsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A815D3A28F15EC5007A6926 /* WebViewVmJSPluginsTests.swift */; };
 		8A815D3D28F16367007A6926 /* JSPluginsProgramImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A815D3C28F16367007A6926 /* JSPluginsProgramImpl.swift */; };
-		8A82CDF02351095700607162 /* HttpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A82CDEF2351095700607162 /* HttpClient.swift */; };
+		8A82CDF02351095700607162 /* HttpClientImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A82CDEF2351095700607162 /* HttpClientImpl.swift */; };
 		8A84DC562677867E000C69DB /* HttpClient+URLSessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A84DC552677867E000C69DB /* HttpClient+URLSessionDelegate.swift */; };
 		8A8EB007245EA1BA0028D35C /* WebViewAuthChallengeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8EB006245EA1B90028D35C /* WebViewAuthChallengeHandler.swift */; };
 		8A8EB008245EA1BA0028D35C /* WebViewAuthChallengeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8EB006245EA1B90028D35C /* WebViewAuthChallengeHandler.swift */; };
@@ -1002,7 +1004,8 @@
 		8A5E6C72290B06790034A78B /* AutoMockable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoMockable.swift; sourceTree = "<group>"; };
 		8A5E6C7D290B0E6C0034A78B /* AutoMockable.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AutoMockable.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A5E6C7F290B0E6C0034A78B /* AutoMockable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AutoMockable.h; sourceTree = "<group>"; };
-		8A5E6C98290B11880034A78B /* Mock.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mock.generated.swift; sourceTree = "<group>"; };
+		8A5E6CAE290B1D4F0034A78B /* RestInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestInterface.swift; sourceTree = "<group>"; };
+		8A5E6CB2290B228B0034A78B /* Mock.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mock.generated.swift; sourceTree = "<group>"; };
 		8A5F71F52826C148008E5638 /* CoreHttpKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CoreHttpKit.xcframework; path = ../CoreHttpKit/build/XCFrameworks/release/CoreHttpKit.xcframework; sourceTree = "<group>"; };
 		8A5FD6A826AF34570019384A /* AppErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrors.swift; sourceTree = "<group>"; };
 		8A624074288D98DA006DDC66 /* SearchSuggestionsViewModelImpl+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchSuggestionsViewModelImpl+AsyncAwait.swift"; sourceTree = "<group>"; };
@@ -1040,7 +1043,7 @@
 		8A8035FC24449C9D000E035F /* GoogleSearchEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleSearchEngine.swift; sourceTree = "<group>"; };
 		8A815D3A28F15EC5007A6926 /* WebViewVmJSPluginsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewVmJSPluginsTests.swift; sourceTree = "<group>"; };
 		8A815D3C28F16367007A6926 /* JSPluginsProgramImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSPluginsProgramImpl.swift; sourceTree = "<group>"; };
-		8A82CDEF2351095700607162 /* HttpClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpClient.swift; sourceTree = "<group>"; };
+		8A82CDEF2351095700607162 /* HttpClientImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpClientImpl.swift; sourceTree = "<group>"; };
 		8A84DC552677867E000C69DB /* HttpClient+URLSessionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HttpClient+URLSessionDelegate.swift"; sourceTree = "<group>"; };
 		8A8EB006245EA1B90028D35C /* WebViewAuthChallengeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewAuthChallengeHandler.swift; sourceTree = "<group>"; };
 		8A90636824332376009D786E /* URL+CoreExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+CoreExtensions.swift"; sourceTree = "<group>"; };
@@ -1243,6 +1246,7 @@
 				8A7B1BCC28EB16F4004FC135 /* HttpKit.framework in Frameworks */,
 				8A7B1BEF28EB18DB004FC135 /* CoreHttpKit.xcframework in Frameworks */,
 				8A7B1BE428EB1771004FC135 /* CoreBrowser.framework in Frameworks */,
+				8A5E6CB1290B21B50034A78B /* Alamofire in Frameworks */,
 				8AB9BE2C28FF149A002063C2 /* FeaturesFlagsKit.framework in Frameworks */,
 				8A7B1BD828EB172A004FC135 /* BrowserNetworking.framework in Frameworks */,
 			);
@@ -1835,7 +1839,7 @@
 		8A5E6C75290B0C430034A78B /* GeneratedMocks */ = {
 			isa = PBXGroup;
 			children = (
-				8A5E6C98290B11880034A78B /* Mock.generated.swift */,
+				8A5E6CB2290B228B0034A78B /* Mock.generated.swift */,
 			);
 			path = GeneratedMocks;
 			sourceTree = "<group>";
@@ -2203,7 +2207,8 @@
 				8ABDB0B927B2B6F200D6EDE7 /* HTTPAdapter.swift */,
 				8AB4A1B427B55684008030FB /* HTTPVoidAdapter.swift */,
 				8A328F3427B690980021F6B0 /* NetworkReachabilityAdapter.swift */,
-				8A82CDEF2351095700607162 /* HttpClient.swift */,
+				8A5E6CAE290B1D4F0034A78B /* RestInterface.swift */,
+				8A82CDEF2351095700607162 /* HttpClientImpl.swift */,
 				8AB4A1AB27B53043008030FB /* ClientSubscriber.swift */,
 				8ACAE08E27B7DF52001D9DCD /* DummyRxInterface.swift */,
 				8AC45ECC2458327D007E47EE /* HttpClient+Combine.swift */,
@@ -2504,6 +2509,7 @@
 			name = CoreCatowser;
 			packageProductDependencies = (
 				8AD4F51928F49208009C4BDC /* ReactiveSwift */,
+				8A5E6CB0290B21B50034A78B /* Alamofire */,
 			);
 			productName = CoreCatowser;
 			productReference = 8A7B1B9828EB131E004FC135 /* CoreCatowser.framework */;
@@ -3509,7 +3515,7 @@
 				8A06D6FA28EC2FC8001CB63D /* ReachabilityAdapteeMocks.swift in Sources */,
 				8ACE7BEA28ED4F10001CBAED /* DNSResolvingStrategyMocks.swift in Sources */,
 				8AC6D5F928F008EC008379C0 /* NavigationActionableMocks.swift in Sources */,
-				8A5E6C99290B11880034A78B /* Mock.generated.swift in Sources */,
+				8A5E6CB3290B228B0034A78B /* Mock.generated.swift in Sources */,
 				8A06D6F728EC2CF8001CB63D /* ServerDescriptionMocks.swift in Sources */,
 				8A06D6F528EC2C5D001CB63D /* ResponseTypeMocks.swift in Sources */,
 				8ACE7BEC28ED4FC9001CBAED /* WebViewContextMocks.swift in Sources */,
@@ -3689,7 +3695,7 @@
 				8A1C1BD9280B1E2D009B9363 /* HttpClient+Kotlin.swift in Sources */,
 				8ABDB0BA27B2B6F200D6EDE7 /* HTTPAdapter.swift in Sources */,
 				8AB4A1AF27B5522B008030FB /* ClosureWrappers.swift in Sources */,
-				8A82CDF02351095700607162 /* HttpClient.swift in Sources */,
+				8A82CDF02351095700607162 /* HttpClientImpl.swift in Sources */,
 				8AB4A1AD27B5335C008030FB /* ClientSubscriber.swift in Sources */,
 				8A7A9BAC23F1C477008850B6 /* URL+Extensions.swift in Sources */,
 				8AB4A1B127B55268008030FB /* ResponseHandlingApiType.swift in Sources */,
@@ -3699,6 +3705,7 @@
 				8A68E40E245966190070F338 /* CombineExtensions.swift in Sources */,
 				8ACAE08F27B7DF52001D9DCD /* DummyRxInterface.swift in Sources */,
 				8AB4A1B927B583AB008030FB /* ClosureVoidWrappers.swift in Sources */,
+				8A5E6CAF290B1D4F0034A78B /* RestInterface.swift in Sources */,
 				8AB4A1B527B55684008030FB /* HTTPVoidAdapter.swift in Sources */,
 				8AB5B3C6280C92B1001F8644 /* HttpKotlinTypes+Extensions.swift in Sources */,
 				8A328F3527B690980021F6B0 /* NetworkReachabilityAdapter.swift in Sources */,
@@ -4414,7 +4421,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 andreiermoshin. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -4454,7 +4461,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 andreiermoshin. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -5387,6 +5394,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 8A03F45828F47ACB00E4A296 /* XCRemoteSwiftPackageReference "SwiftSoup" */;
 			productName = SwiftSoup;
+		};
+		8A5E6CB0290B21B50034A78B /* Alamofire */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8AC4365C247910E1008DD663 /* XCRemoteSwiftPackageReference "Alamofire" */;
+			productName = Alamofire;
 		};
 		8AA6608928F43F790058490F /* SWXMLHash */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/catowser/catowser.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/catowser/catowser.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "aexml",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tadija/AEXML.git",
+      "state" : {
+        "revision" : "38f7d00b23ecd891e1ee656fa6aeebd6ba04ecc3",
+        "version" : "4.6.1"
+      }
+    },
+    {
       "identity" : "alamofire",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Alamofire/Alamofire.git",
@@ -19,12 +28,66 @@
       }
     },
     {
+      "identity" : "chalk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/luoxiu/Chalk",
+      "state" : {
+        "revision" : "8a9d3373bd754fb62f7881d9f639d376f5e4d5a5",
+        "version" : "0.2.1"
+      }
+    },
+    {
+      "identity" : "commander",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/Commander",
+      "state" : {
+        "revision" : "4a1f2fb82fb6cef613c4a25d2e38f702e4d812c2",
+        "version" : "0.9.2"
+      }
+    },
+    {
+      "identity" : "pathkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/PathKit",
+      "state" : {
+        "revision" : "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+        "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "rainbow",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/luoxiu/Rainbow",
+      "state" : {
+        "revision" : "9d8fcb4c64e816a135c31162a0c319e9f1f09c35",
+        "version" : "0.1.1"
+      }
+    },
+    {
       "identity" : "reactiveswift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ReactiveCocoa/ReactiveSwift",
       "state" : {
         "revision" : "efb2f0a6f6c8739cce8fb14148a5bd3c83f2f91d",
         "version" : "7.0.0"
+      }
+    },
+    {
+      "identity" : "shellout",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/ShellOut",
+      "state" : {
+        "revision" : "e1577acf2b6e90086d01a6d5e2b8efdaae033568",
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "spectre",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/Spectre.git",
+      "state" : {
+        "revision" : "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+        "version" : "0.10.1"
       }
     },
     {
@@ -37,12 +100,39 @@
       }
     },
     {
+      "identity" : "swiftymocky",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/MakeAWishFoundation/SwiftyMocky",
+      "state" : {
+        "revision" : "1e81c0c566c26d2d4e4cc2d799afad7d3ef931ab",
+        "version" : "4.2.0"
+      }
+    },
+    {
       "identity" : "swxmlhash",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/drmohundro/SWXMLHash",
       "state" : {
         "revision" : "4d0f62f561458cbe1f732171e625f03195151b60",
         "version" : "7.0.1"
+      }
+    },
+    {
+      "identity" : "xcodeproj",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tuist/xcodeproj",
+      "state" : {
+        "revision" : "b6de1bfe021b861c94e7c83821b595083f74b997",
+        "version" : "8.8.0"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams",
+      "state" : {
+        "revision" : "81a65c4069c28011ee432f2858ba0de49b086677",
+        "version" : "3.0.1"
       }
     }
   ],

--- a/catowser/catowser/Environment/ViewModelFactory.swift
+++ b/catowser/catowser/Environment/ViewModelFactory.swift
@@ -18,20 +18,20 @@ final class ViewModelFactory {
     
     func searchSuggestionsViewModel() -> SearchSuggestionsViewModel {
         let searchProviderType = FeatureManager.webSearchAutoCompleteValue()
-
+        let vmContext: SearchViewContextImpl = .init()
         switch searchProviderType {
         case .google:
             let context = GoogleContext(HttpEnvironment.shared.googleClient,
                                         HttpEnvironment.shared.googleClientRxSubscriber,
                                         HttpEnvironment.shared.googleClientSubscriber)
             let strategy = GoogleAutocompleteStrategy(context)
-            return SearchSuggestionsViewModelImpl(strategy, FeatureManager.shared)
+            return SearchSuggestionsViewModelImpl(strategy, vmContext)
         case .duckduckgo:
             let context = DDGoContext(HttpEnvironment.shared.duckduckgoClient,
                                       HttpEnvironment.shared.duckduckgoClientRxSubscriber,
                                       HttpEnvironment.shared.duckduckgoClientSubscriber)
             let strategy = DDGoAutocompleteStrategy(context)
-            return SearchSuggestionsViewModelImpl(strategy, FeatureManager.shared)
+            return SearchSuggestionsViewModelImpl(strategy, vmContext)
         }
     }
     
@@ -42,12 +42,5 @@ final class ViewModelFactory {
         
         let strategy = GoogleDNSStrategy(stratContext)
         return WebViewModelImpl(strategy, site, context)
-    }
-}
-
-extension FeatureManager: SearchViewContext {
-    public func appAsyncApiTypeValue() -> AsyncApiType {
-        // Temporarily use static method in non static
-        FeatureManager.appAsyncApiTypeValue()
     }
 }

--- a/catowser/catowser/Search/SearchViewContextImpl.swift
+++ b/catowser/catowser/Search/SearchViewContextImpl.swift
@@ -1,0 +1,22 @@
+//
+//  SearchViewContextImpl.swift
+//  catowser
+//
+//  Created by Andrei Ermoshin on 11/4/22.
+//  Copyright © 2022 andreiermoshin. All rights reserved.
+//
+
+import Foundation
+import CoreCatowser
+import CoreBrowser
+import FeaturesFlagsKit
+
+struct SearchViewContextImpl: SearchViewContext {
+    var knownDomainsStorage: KnownDomainsSource {
+        InMemoryDomainSearchProvider.shared
+    }
+    
+    var appAsyncApiTypeValue: AsyncApiType {
+        FeatureManager.appAsyncApiTypeValue()
+    }
+}


### PR DESCRIPTION
###  Changes
- add SwiftyMocky dependency to be able to generate mocks for complex swift protocols with associated types and constraints.
- implement unit tests for Search auto-complete VM and related types.
- ability to build unit tests for macOS platform (part of SwiftyMocky uses specific macOS APIs)
- update RestClient to confirm to generic swift protocol to be able to mock it

### Docs
https://github.com/kyzmitch/CatowserEvolution/blob/master/0028-mock-tools.md